### PR TITLE
Ignore 202 response codes on home key presses

### DIFF
--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -93,7 +93,7 @@ describe('index', () => {
                 return {} as any;
             });
 
-            let results = await (rokuDeploy as any).doPostRequest({});
+            let results = await (rokuDeploy as any).doPostRequest({}, true);
             expect(results.body).to.equal(body);
         });
 
@@ -105,12 +105,39 @@ describe('index', () => {
             });
 
             try {
-                await (rokuDeploy as any).doPostRequest({});
+                await (rokuDeploy as any).doPostRequest({}, true);
             } catch (e) {
                 expect(e).to.equal(error);
                 return;
             }
             assert.fail('Exception should have been thrown');
+        });
+
+        it('should throw an error for a wrong response code if verify is true', async () => {
+            let body = 'responseBody';
+            sinon.stub(rokuDeploy.request, 'post').callsFake((_, callback) => {
+                process.nextTick(callback, undefined, { statusCode: 500 }, body);
+                return {} as any;
+            });
+
+            try {
+                await (rokuDeploy as any).doPostRequest({}, true);
+            } catch (e) {
+                expect(e).to.be.instanceof(errors.InvalidDeviceResponseCodeError);
+                return;
+            }
+            assert.fail('Exception should have been thrown');
+        });
+
+        it('should not throw an error for a response code if verify is false', async () => {
+            let body = 'responseBody';
+            sinon.stub(rokuDeploy.request, 'post').callsFake((_, callback) => {
+                process.nextTick(callback, undefined, { statusCode: 500 }, body);
+                return {} as any;
+            });
+
+            let results = await (rokuDeploy as any).doPostRequest({}, false);
+            expect(results.body).to.equal(body);
         });
     });
 

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -423,7 +423,7 @@ export class RokuDeploy {
         // press the home button to return to the main screen
         return this.doPostRequest({
             url: `http://${host}:${port}/keypress/Home`
-        });
+        }, false);
     }
 
     /**
@@ -610,7 +610,7 @@ export class RokuDeploy {
      * Centralized function for handling POST http requests
      * @param params
      */
-    private async doPostRequest(params: any) {
+    private async doPostRequest(params: any, verify = true) {
         let results: { response: any; body: any } = await new Promise((resolve, reject) => {
             this.request.post(params, (err, resp, body) => {
                 if (err) {
@@ -619,7 +619,9 @@ export class RokuDeploy {
                 return resolve({ response: resp, body: body });
             });
         });
-        this.checkRequest(results);
+        if (verify) {
+            this.checkRequest(results);
+        }
         return results;
     }
 


### PR DESCRIPTION
Ignore 202 response codes on home key presses since this should be a fire and forget call anyways and causes issues that really aren't issues when we receive a 202 response code.