### PR TITLE
Fix critical issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -586,7 +586,6 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
             "requires": {
                 "color-convert": "^1.9.0"
             }
@@ -763,7 +762,6 @@
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
             "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
             "requires": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -843,7 +841,6 @@
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
             "requires": {
                 "color-name": "1.1.3"
             }
@@ -851,8 +848,7 @@
         "color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "combined-stream": {
             "version": "1.0.8",
@@ -1119,8 +1115,7 @@
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "eslint": {
             "version": "6.8.0",
@@ -1603,8 +1598,7 @@
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "has-symbols": {
             "version": "1.0.1",
@@ -3319,7 +3313,6 @@
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
             "requires": {
                 "has-flag": "^3.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "publish-coverage": "nyc report --reporter=text-lcov | coveralls"
     },
     "dependencies": {
+        "chalk": "^2.4.2",
         "dateformat": "^3.0.3",
         "eventemitter3": "^4.0.7",
         "fs-extra": "^7.0.1",

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -455,7 +455,7 @@ describe('index', () => {
             const zip = await JSZip.loadAsync(data);
 
             for (const file of files) {
-                const zipFileContents = await zip.file(s`${file.toString()}`).async('string');
+                const zipFileContents = await zip.file(file.toString()).async('string');
                 const sourcePath = path.join(options.rootDir, file);
                 const incomingContents = fsExtra.readFileSync(sourcePath, 'utf8');
                 expect(zipFileContents).to.equal(incomingContents);
@@ -479,7 +479,7 @@ describe('index', () => {
             const zip = await JSZip.loadAsync(data);
 
             for (const file of files) {
-                const zipFileContents = await zip.file(s`${file.toString()}`).async('string');
+                const zipFileContents = await zip.file(file.toString()).async('string');
                 const sourcePath = path.join(options.rootDir, file);
                 const incomingContents = fsExtra.readFileSync(sourcePath, 'utf8');
                 expect(zipFileContents).to.equal(incomingContents);
@@ -1541,7 +1541,7 @@ describe('index', () => {
             const data = fsExtra.readFileSync(outputZipPath);
             const zip = await JSZip.loadAsync(data);
             for (const file of files) {
-                const zipFileContents = await zip.file(s`${file.toString()}`).async('string');
+                const zipFileContents = await zip.file(file.toString()).async('string');
                 const sourcePath = path.join(options.rootDir, file);
                 const incomingContents = fsExtra.readFileSync(sourcePath, 'utf8');
                 if (file === 'manifest') {

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -956,7 +956,7 @@ export class RokuDeploy {
                 if (ext === '.jpg' || ext === '.png' || ext === '.jpeg') {
                     compression = 'STORE';
                 }
-                zip.file(file.dest, data, {
+                zip.file(file.dest.replace(/[\\/]/g, '/'), data, {
                     compression: compression
                 });
             });


### PR DESCRIPTION
Fix issues with latest release that crash for windows slashes.
Add missing `chalk` dependency.

Fixes https://github.com/rokucommunity/vscode-brightscript-language/issues/315
Fixes https://github.com/rokucommunity/vscode-brightscript-language/issues/314