### PR TITLE
wraps call to delete installed cahnnel in try catch, so that deployments continue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1544,9 +1544,9 @@
             }
         },
         "glob-parent": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-            "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "dev": true,
             "requires": {
                 "is-glob": "^4.0.1"

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -1494,6 +1494,15 @@ describe('index', () => {
             let result = await rokuDeploy.deploy();
             expect(result).not.to.be.undefined;
         });
+        it('continues with deploy if deleteInstalledChannel fails', async () => {
+            sinon.stub(rokuDeploy, 'deleteInstalledChannel').callsFake(() => {
+                throw new Error('Crash baby crash');
+            });
+            mockDoPostRequest();
+            let result = await rokuDeploy.deploy();
+            expect(result).not.to.be.undefined;
+        });
+
     });
 
     describe('deleteInstalledChannel', () => {

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -1494,15 +1494,20 @@ describe('index', () => {
             let result = await rokuDeploy.deploy();
             expect(result).not.to.be.undefined;
         });
+
         it('continues with deploy if deleteInstalledChannel fails', async () => {
-            sinon.stub(rokuDeploy, 'deleteInstalledChannel').callsFake(() => {
-                throw new Error('Crash baby crash');
-            });
+            sinon.stub(rokuDeploy, 'deleteInstalledChannel').returns(
+                Promise.reject(
+                    new Error('failed')
+                )
+            );
             mockDoPostRequest();
-            let result = await rokuDeploy.deploy();
+            let result = await rokuDeploy.deploy({
+                //something in the previous test is locking the default output zip file. We should fix that at some point...
+                outDir: s`${tmpPath}/test1`
+            });
             expect(result).not.to.be.undefined;
         });
-
     });
 
     describe('deleteInstalledChannel', () => {

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -714,7 +714,11 @@ export class RokuDeploy {
     public async deploy(options?: RokuDeployOptions, beforeZipCallback?: (info: BeforeZipCallbackInfo) => void) {
         options = this.getOptions(options);
         await this.createPackage(options, beforeZipCallback);
-        await this.deleteInstalledChannel(options);
+        try {
+            await this.deleteInstalledChannel(options);
+        } catch (e) {
+            // note we don't report the error; as we don't actually care that we could not deploy - it's just useless noise to log it.
+        }
         let result = await this.publish(options);
         return result;
     }


### PR DESCRIPTION
addresses: https://github.com/rokucommunity/roku-deploy/issues/64