### PR TITLE
run replace first, then fallback to replace.

### DIFF
--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -824,7 +824,6 @@ describe('index', () => {
             }
             assert.fail('Should not have succeeded');
         });
-
     });
 
     describe('convertToSquashfs', () => {
@@ -864,6 +863,18 @@ describe('index', () => {
             </device-info>`;
             mockDoGetRequest(body);
             fsExtra.outputFileSync(`${rootDir}/${options.rekeySignedPackage}`, '');
+        });
+
+        it('does not crash when archive is undefined', async () => {
+            const expectedError = new Error('Custom error');
+            sinon.stub(fsExtra, 'createReadStream').throws(expectedError);
+            let actualError: Error;
+            try {
+                await rokuDeploy.rekeyDevice(options);
+            } catch (e) {
+                actualError = e as Error;
+            }
+            expect(actualError).to.equal(expectedError);
         });
 
         it('should work with relative path', async () => {


### PR DESCRIPTION
Sometimes a "replace" command will fail on roku devices, so if that happens, we fall back to an "install" call which should work the rest of the time. 

I also made the `generateBaseRequestOptions` function take a formData object to simplify callsite code.