### PR TITLE
Use ip address for ECP press

### DIFF
--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -435,10 +435,12 @@ export class RokuDeploy {
      * @param port - the port that should be used for the request. defaults to 8060
      * @param timeout - request timeout duration in milliseconds. defaults to 150000
      */
-    public async pressHomeButton(host, port?: number, timeout?: number) {
+    public async pressHomeButton(host: string, port?: number, timeout?: number) {
         let options = this.getOptions();
         port = port ? port : options.remotePort;
         timeout = timeout ? timeout : options.timeout;
+        //convert hostname to ip address because ECP commands only work with IP addresses
+        host = await util.dnsLookup(host);
         // press the home button to return to the main screen
         return this.doPostRequest({
             url: `http://${host}:${port}/keypress/Home`,

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,7 @@
 import * as fsExtra from 'fs-extra';
 import * as path from 'path';
 import * as fs from 'fs';
+import * as dns from 'dns';
 
 export class Util {
     /**
@@ -124,6 +125,24 @@ export class Util {
         }
         return false;
     }
+
+    /**
+     * Look up the ip address for a hostname. This is cached for the lifetime of the app, or bypassed with the `skipCache` parameter
+     * @param host
+     * @param skipCache
+     * @returns
+     */
+    public async dnsLookup(host: string, skipCache = false) {
+        if (!this.dnsCache.has(host) || skipCache) {
+            const result = (await dns.promises.lookup(host)).address;
+            this.dnsCache.set(host, result);
+            return result;
+        } else {
+            return this.dnsCache.get(host);
+        }
+    }
+
+    private dnsCache = new Map<string, string>();
 }
 
 export let util = new Util();


### PR DESCRIPTION
ECP requests will fail if using a hostname instead of an ip address, so this will convert the hostname to an ip address only for the `pressHomeButton` call.