### PR TITLE
fix order-of-ops issue with rekeyDevice call

### DIFF
--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -558,8 +558,10 @@ export class RokuDeploy {
             archive: null as _fsExtra.ReadStream
         });
 
+        let results: HttpResponse;
         try {
             requestOptions.formData.archive = this.fsExtra.createReadStream(rekeySignedPackagePath);
+            results = await this.doPostRequest(requestOptions);
         } finally {
             //ensure the stream is closed
             try {
@@ -567,7 +569,6 @@ export class RokuDeploy {
             } catch { }
         }
 
-        let results = await this.doPostRequest(requestOptions);
         let resultTextSearch = /<font color="red">([^<]+)<\/font>/.exec(results.body);
         if (!resultTextSearch) {
             throw new errors.UnparsableDeviceResponseError('Unknown Rekey Failure');


### PR DESCRIPTION
v3.5.0 introduced a bug where we closed the read stream before sending the request to the server. This fixes that problem.