### PR TITLE
Remove `request` prop from `RokuDeploy` class

### DIFF
--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -13,6 +13,7 @@ import { util, standardizePath as s } from './util';
 import type { FileEntry, RokuDeployOptions } from './RokuDeployOptions';
 import { cwd, expectPathExists, expectPathNotExists, expectThrowsAsync, outDir, rootDir, stagingDir, tempDir, writeFiles } from './testUtils.spec';
 import { createSandbox } from 'sinon';
+import * as request from 'request';
 const sinon = createSandbox();
 
 describe('index', () => {
@@ -82,7 +83,7 @@ describe('index', () => {
     describe('doPostRequest', () => {
         it('should not throw an error for a successful request', async () => {
             let body = 'responseBody';
-            sinon.stub(rokuDeploy.request, 'post').callsFake((_, callback) => {
+            sinon.stub(request, 'post').callsFake((_, callback) => {
                 process.nextTick(callback, undefined, { statusCode: 200 }, body);
                 return {} as any;
             });
@@ -93,7 +94,7 @@ describe('index', () => {
 
         it('should throw an error for a network error', async () => {
             let error = new Error('Network Error');
-            sinon.stub(rokuDeploy.request, 'post').callsFake((_, callback) => {
+            sinon.stub(request, 'post').callsFake((_, callback) => {
                 process.nextTick(callback, error);
                 return {} as any;
             });
@@ -109,7 +110,7 @@ describe('index', () => {
 
         it('should throw an error for a wrong response code if verify is true', async () => {
             let body = 'responseBody';
-            sinon.stub(rokuDeploy.request, 'post').callsFake((_, callback) => {
+            sinon.stub(request, 'post').callsFake((_, callback) => {
                 process.nextTick(callback, undefined, { statusCode: 500 }, body);
                 return {} as any;
             });
@@ -125,7 +126,7 @@ describe('index', () => {
 
         it('should not throw an error for a response code if verify is false', async () => {
             let body = 'responseBody';
-            sinon.stub(rokuDeploy.request, 'post').callsFake((_, callback) => {
+            sinon.stub(request, 'post').callsFake((_, callback) => {
                 process.nextTick(callback, undefined, { statusCode: 500 }, body);
                 return {} as any;
             });
@@ -138,7 +139,7 @@ describe('index', () => {
     describe('doGetRequest', () => {
         it('should not throw an error for a successful request', async () => {
             let body = 'responseBody';
-            sinon.stub(rokuDeploy.request, 'get').callsFake((_, callback) => {
+            sinon.stub(request, 'get').callsFake((_, callback) => {
                 process.nextTick(callback, undefined, { statusCode: 200 }, body);
                 return {} as any;
             });
@@ -149,7 +150,7 @@ describe('index', () => {
 
         it('should throw an error for a network error', async () => {
             let error = new Error('Network Error');
-            sinon.stub(rokuDeploy.request, 'get').callsFake((_, callback) => {
+            sinon.stub(request, 'get').callsFake((_, callback) => {
                 process.nextTick(callback, error);
                 return {} as any;
             });
@@ -570,7 +571,7 @@ describe('index', () => {
     describe('pressHomeButton', () => {
         it('rejects promise on error', () => {
             //intercept the post requests
-            sinon.stub(rokuDeploy.request, 'post').callsFake((_, callback) => {
+            sinon.stub(request, 'post').callsFake((_, callback) => {
                 process.nextTick(callback, new Error());
                 return {} as any;
             });
@@ -704,7 +705,7 @@ describe('index', () => {
 
         it('throws when package upload fails', async () => {
             //intercept the post requests
-            sinon.stub(rokuDeploy.request, 'post').callsFake((data: any, callback: any) => {
+            sinon.stub(request, 'post').callsFake((data: any, callback: any) => {
                 if (data.url === `http://${options.host}/plugin_install`) {
                     process.nextTick(() => {
                         callback(new Error('Failed to publish to server'));
@@ -993,7 +994,7 @@ describe('index', () => {
             let error = new Error('Network Error');
             try {
                 //intercept the post requests
-                sinon.stub(rokuDeploy.request, 'post').callsFake((_, callback) => {
+                sinon.stub(request, 'post').callsFake((_, callback) => {
                     process.nextTick(callback, error);
                     return {} as any;
                 });
@@ -2349,17 +2350,17 @@ describe('index', () => {
             sinon.stub(rokuDeploy.fsExtra, 'createWriteStream').returns(null);
 
             //intercept the http request
-            sinon.stub(rokuDeploy.request, 'get').callsFake(() => {
-                let request: any = {
+            sinon.stub(request, 'get').callsFake(() => {
+                let req: any = {
                     on: (event, callback) => {
                         process.nextTick(() => {
                             onHandler(event, callback);
                         });
-                        return request;
+                        return req;
                     },
                     pipe: () => { }
                 };
-                return request;
+                return req;
             });
 
         });

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -25,8 +25,6 @@ export class RokuDeploy {
     private logger: Logger;
     //store the import on the class to make testing easier
 
-    public request = request;
-
     public fsExtra = _fsExtra;
 
     /**
@@ -637,7 +635,7 @@ export class RokuDeploy {
         let writeStream: _fsExtra.WriteStream;
         return new Promise<string>((resolve, reject) => {
             writeStream = this.fsExtra.createWriteStream(pkgFilePath);
-            this.request.get(requestOptions)
+            request.get(requestOptions)
                 .on('error', (err) => {
                     try {
                         writeStream.close();
@@ -661,7 +659,7 @@ export class RokuDeploy {
      */
     private async doPostRequest(params: any, verify = true) {
         let results: { response: any; body: any } = await new Promise((resolve, reject) => {
-            this.request.post(params, (err, resp, body) => {
+            request.post(params, (err, resp, body) => {
                 if (err) {
                     return reject(err);
                 }
@@ -680,7 +678,7 @@ export class RokuDeploy {
      */
     private async doGetRequest(params: any) {
         let results: { response: any; body: any } = await new Promise((resolve, reject) => {
-            this.request.get(params, (err, resp, body) => {
+            request.get(params, (err, resp, body) => {
                 if (err) {
                     return reject(err);
                 }


### PR DESCRIPTION
Importing roku-deploy into a typescript project sometimes shows type errors because of a missing `@types/request` package. This is a devDependency, so it shouldn't clutter the production dependencies. 

Also, we're only storing `request` on `RokuDeploy` to help with unit testing. However, we don't actually need to do that, since we  can already stub/mock the `request` object as long as it's imported as `import * as request from 'request'`. 

This _might_ be a breaking change if any projects were utilizing the `rokuDeploy.request` property, but realistically that should have been a private property anyway, and there's an easy fix (import `request` in the host project...). 

![image](https://user-images.githubusercontent.com/2544493/154313289-113cdbfd-3818-4eec-97d9-41665e934eeb.png)
