### PR TITLE
Add deleteInstalledChannel option

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Here are the available options. The defaults are shown to the right of the optio
      When publishing a side loaded channel this flag can be used to enable the socket based BrightScript debug protocol. This should always be `false` unless you're creating a plugin for an editor such as VSCode, Atom, Sublime, etc.
      More information on the BrightScript debug protocol can be found here: https://developer.roku.com/en-ca/docs/developer-program/debugging/socket-based-debugger.md
 
-- **remotePort?:** boolean = true
+- **deleteInstalledChannel?:** boolean = true
     If true the previously installed dev channel will be deleted before installing the new one
 
 

--- a/README.md
+++ b/README.md
@@ -320,9 +320,13 @@ Here are the available options. The defaults are shown to the right of the optio
 
 - **remotePort?:** string = 8060
     The port used for sending remote control commands (like home press or back press). This is mainly used for things like emulators, or when your roku is behind a firewall with a port-forward.
+
 - **remoteDebug?:** boolean = false
      When publishing a side loaded channel this flag can be used to enable the socket based BrightScript debug protocol. This should always be `false` unless you're creating a plugin for an editor such as VSCode, Atom, Sublime, etc.
      More information on the BrightScript debug protocol can be found here: https://developer.roku.com/en-ca/docs/developer-program/debugging/socket-based-debugger.md
+
+- **remotePort?:** boolean = true
+    If true the previously installed dev channel will be deleted before installing the new one
 
 
 Click [here](https://github.com/rokucommunity/roku-deploy/blob/8e1cbdfcccb38dad4a1361277bdaf5484f1c2bcd/src/RokuDeploy.ts#L897) to see the typescript interface for these options

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -1537,6 +1537,26 @@ describe('index', () => {
             });
             expect(result).not.to.be.undefined;
         });
+
+        it('should delete installed channel if requested', async () => {
+            const spy = sinon.spy(rokuDeploy, 'deleteInstalledChannel');
+            options.deleteInstalledChannel = true;
+            mockDoPostRequest();
+
+            await rokuDeploy.deploy(options);
+
+            expect(spy.called).to.equal(true);
+        });
+
+        it('should not delete installed channel if not requested', async () => {
+            const spy = sinon.spy(rokuDeploy, 'deleteInstalledChannel');
+            options.deleteInstalledChannel = false;
+            mockDoPostRequest();
+
+            await rokuDeploy.deploy(options);
+
+            expect(spy.notCalled).to.equal(true);
+        });
     });
 
     describe('deleteInstalledChannel', () => {
@@ -2644,6 +2664,16 @@ describe('index', () => {
 
         it('does not error when no parameter provided', () => {
             expect(rokuDeploy.getOptions(undefined)).to.exist;
+        });
+
+        describe('deleteInstalledChannel', () => {
+            it('defaults to true', () => {
+                expect(rokuDeploy.getOptions({}).deleteInstalledChannel).to.equal(true);
+            });
+
+            it('can be overridden', () => {
+                expect(rokuDeploy.getOptions({ deleteInstalledChannel: false }).deleteInstalledChannel).to.equal(false);
+            });
         });
 
         describe('packagePort', () => {

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -705,10 +705,12 @@ export class RokuDeploy {
     public async deploy(options?: RokuDeployOptions, beforeZipCallback?: (info: BeforeZipCallbackInfo) => void) {
         options = this.getOptions(options);
         await this.createPackage(options, beforeZipCallback);
-        try {
-            await this.deleteInstalledChannel(options);
-        } catch (e) {
-            // note we don't report the error; as we don't actually care that we could not deploy - it's just useless noise to log it.
+        if (options.deleteInstalledChannel) {
+            try {
+                await this.deleteInstalledChannel(options);
+            } catch (e) {
+                // note we don't report the error; as we don't actually care that we could not deploy - it's just useless noise to log it.
+            }
         }
         let result = await this.publish(options);
         return result;
@@ -789,6 +791,7 @@ export class RokuDeploy {
             retainDeploymentArchive: true,
             incrementBuildNumber: false,
             failOnCompileError: true,
+            deleteInstalledChannel: true,
             packagePort: 80,
             remotePort: 8060,
             timeout: 150000,

--- a/src/RokuDeployOptions.ts
+++ b/src/RokuDeployOptions.ts
@@ -139,6 +139,11 @@ export interface RokuDeployOptions {
      * @default LogLevel.log
      */
     logLevel?: LogLevel;
+
+    /**
+     * If true, the previously installed dev channel will be deleted before installing the new one
+     */
+    deleteInstalledChannel?: boolean;
 }
 
 export type FileEntry = (string | { src: string | string[]; dest?: string });


### PR DESCRIPTION
Just wanted to add an option to not delete the previously installed channel upon publishing as sometimes it proves to be unneccesary and delete local storage files associated with the channel and can slow down iteration time.