### PR TITLE
Allow filtering files during `zipFolder`

### DIFF
--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -1869,6 +1869,35 @@ describe('index', () => {
                 }
             }
         });
+
+        it('filters the folders before making the zip', async () => {
+            const files = [
+                'components/MainScene.brs',
+                'components/MainScene.brs.map',
+                'images/splash_hd.jpg',
+                'source/main.brs',
+                'source/main.brs.map',
+                'manifest'
+            ];
+            writeFiles(stagingDir, files);
+
+            const outputZipPath = path.join(tempDir, 'output.zip');
+            await rokuDeploy.zipFolder(stagingDir, outputZipPath, null, ['**/*', '!**/*.map']);
+
+            const data = fsExtra.readFileSync(outputZipPath);
+            const zip = await JSZip.loadAsync(data);
+            //the .map files should be missing
+            expect(
+                Object.keys(zip.files).sort()
+            ).to.eql(
+                [
+                    'source/',
+                    'images/',
+                    'components/',
+                    ...files
+                ].sort().filter(x => !x.endsWith('.map'))
+            );
+        });
     });
 
     describe('parseManifest', () => {

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -967,16 +967,18 @@ export class RokuDeploy {
 
     /**
      * Given a path to a folder, zip up that folder and all of its contents
-     * @param srcFolder
-     * @param zipFilePath
+     * @param srcFolder the folder that should be zipped
+     * @param zipFilePath the path to the zip that will be created
+     * @param preZipCallback a function to call right before every file gets added to the zip
+     * @param files a files array used to filter the files from `srcFolder`
      */
-    public async zipFolder(srcFolder: string, zipFilePath: string, preFileZipCallback?: (file: StandardizedFileEntry, data: Buffer) => Buffer) {
-        const files = await this.getFilePaths(['**/*'], srcFolder);
+    public async zipFolder(srcFolder: string, zipFilePath: string, preFileZipCallback?: (file: StandardizedFileEntry, data: Buffer) => Buffer, files: FileEntry[] = ['**/*']) {
+        const filePaths = await this.getFilePaths(files, srcFolder);
 
         const zip = new JSZip();
         // Allows us to wait until all are done before we build the zip
         const promises = [];
-        for (const file of files) {
+        for (const file of filePaths) {
             const promise = this.fsExtra.readFile(file.src).then((data) => {
                 if (preFileZipCallback) {
                     data = preFileZipCallback(file, data);


### PR DESCRIPTION
Adds a files array parameter to `zipFolder` to allow files to be included/excluded from the zip. This is mostly useful for vscode-brightscript-language to exclude files like sourcemaps from getting uploaded to the device (and save lots of performace doing so). 