### PR TITLE
Better compile error handling

### DIFF
--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -1,3 +1,5 @@
+import type { RokuMessages } from './RokuDeploy';
+
 export class InvalidDeviceResponseCodeError extends Error {
     constructor(message: string, public results?: any) {
         super(message);
@@ -34,7 +36,7 @@ export class UnknownDeviceResponseError extends Error {
 }
 
 export class CompileError extends Error {
-    constructor(message: string, public results: any) {
+    constructor(message: string, public results: any, public rokuMessages: RokuMessages) {
         super(message);
         Object.setPrototypeOf(this, CompileError.prototype);
     }

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -730,6 +730,34 @@ describe('index', () => {
             assert.fail('Should not have succeeded');
         });
 
+        it('rejects as CompileError when initial replace fails', () => {
+            options.failOnCompileError = true;
+            mockDoPostRequest(`
+                Install Failure: Compilation Failed.
+                Shell.create('Roku.Message').trigger('Set message type', 'error').trigger('Set message content', 'Install Failure: Compilation Failed').trigger('Render', node);
+            `);
+
+            return rokuDeploy.publish(options).then(() => {
+                assert.fail('Should not have succeeded due to roku server compilation failure');
+            }, (err) => {
+                expect(err).to.be.instanceOf(errors.CompileError);
+            });
+        });
+
+        it('rejects as CompileError when initial replace fails', () => {
+            options.failOnCompileError = true;
+            mockDoPostRequest(`
+                Install Failure: Compilation Failed.
+                Shell.create('Roku.Message').trigger('Set message type', 'error').trigger('Set message content', 'Install Failure: Compilation Failed').trigger('Render', node);
+            `);
+
+            return rokuDeploy.publish(options).then(() => {
+                assert.fail('Should not have succeeded due to roku server compilation failure');
+            }, (err) => {
+                expect(err).to.be.instanceOf(errors.CompileError);
+            });
+        });
+
         it('rejects when response contains compile error wording', () => {
             options.failOnCompileError = true;
             let body = 'Install Failure: Compilation Failed.';

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -445,12 +445,8 @@ export class RokuDeploy {
                 response = await this.doPostRequest(requestOptions);
             } catch (replaceError: any) {
                 //fail if this is a compile error
-                if (this.isCompileError(replaceError.message)) {
-                    if (options.failOnCompileError) {
-                        throw new errors.CompileError('Compile error', replaceError, replaceError?.results);
-                    } else {
-                        throw new errors.UnknownDeviceResponseError(replaceError.message, response);
-                    }
+                if (this.isCompileError(replaceError.message) && options.failOnCompileError) {
+                    throw new errors.CompileError('Compile error', replaceError, replaceError.results);
                 } else {
                     requestOptions.formData.mysubmit = 'Install';
                     response = await this.doPostRequest(requestOptions);
@@ -485,7 +481,7 @@ export class RokuDeploy {
      * Does the response look like a compile error
      */
     private isCompileError(responseHtml: string) {
-        return responseHtml.includes('Install Failure: Compilation Failed.');
+        return !!/install\sfailure:\scompilation\sfailed/i.exec(responseHtml);
     }
 
     /**
@@ -649,8 +645,6 @@ export class RokuDeploy {
         if (!results || !results.response || typeof results.body !== 'string') {
             throw new errors.UnparsableDeviceResponseError('Invalid response', results);
         }
-
-        // this.logger.trace(results.body);
 
         if (results.response.statusCode === 401) {
             throw new errors.UnauthorizedDeviceResponseError('Unauthorized. Please verify username and password for target Roku.', results);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { RokuDeploy } from './RokuDeploy';
 export * from './RokuDeploy';
 export * from './util';
 export * from './RokuDeployOptions';
+export * from './Errors';
 
 //create a new static instance of RokuDeploy, and export those functions for backwards compatibility
 export const rokuDeploy = new RokuDeploy();


### PR DESCRIPTION
- Detect compile errors on the `replace` call, which prevents retrying with `install` if failed.
- Attach the roku messages to the `CompileError` class.
- Export the error classes