### PR TITLE
Add stagingDir and retainStagingDir.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ If you'd like to use roku-deploy to copy files to a staging folder, you can do t
 ```typescript
 rokuDeploy.prepublishToStaging({
     rootDir: "folder/with/your/source/code",
-    stagingFolderPath: 'path/to/staging/folder',
+    stagingDir: 'path/to/staging/folder',
     files: [
         "source/**/*",
         "components/**/*",
@@ -93,7 +93,7 @@ Use this logic if you'd like to create a zip from your application folder.
 /create a signed package of your project
 rokuDeploy.zipPackage({
     outDir: 'folder/to/put/zip',
-    stagingFolderPath: 'path/to/files/to/zip',
+    stagingDir: 'path/to/files/to/zip',
     outFile: 'filename-of-your-app.zip'
     //...other options if necessary
 }).then(function(){
@@ -135,7 +135,7 @@ From an npm script in `package.json`. (Requires `rokudeploy.json` to exist at th
 You can provide a callback in any of the higher level methods, which allows you to modify the copied contents before the package is zipped. An info object is passed in with the following attributes
 - **manifestData:** [key: string]: string
     Contains all the parsed values from the manifest file
-- **stagingFolderPath:** string
+- **stagingDir:** string
     Path to staging folder to make it so you only need to know the relative path to what you're trying to modify
 
     ```javascript
@@ -148,7 +148,7 @@ You can provide a callback in any of the higher level methods, which allows you 
     rokuDeploy.deploy(options, (info) => {
         //modify staging dir before it's zipped.
         //At this point, all files have been copied to the staging directory.
-        manipulateFilesInStagingFolder(info.stagingFolderPath)
+        manipulateFilesInStagingFolder(info.stagingDir)
         //this function can also return a promise,
         //which will be awaited before roku-deploy starts deploying.
     }).then(function(){
@@ -361,7 +361,7 @@ Here are the available options. The defaults are shown to the right of the optio
 - **retainStagingFolder?:** boolean = `false`
     Set this to true to prevent the staging folder from being deleted after creating the package. This is helpful for troubleshooting why your package isn't being created the way you expected.
 
-- **stagingFolderPath?:** string = `` `${options.outDir}/.roku-deploy-staging` ``
+- **stagingDir?:** string = `` `${options.outDir}/.roku-deploy-staging` ``
    The path to the staging folder (where roku-deploy places all of the files right before zipping them up).
 
 - **convertToSquashfs?:** boolean = `false`

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -37,12 +37,12 @@ export class RokuDeploy {
         options = this.getOptions(options);
 
         //clean the staging directory
-        await this.fsExtra.remove(options.stagingFolderPath);
+        await this.fsExtra.remove(options.stagingDir);
 
         //make sure the staging folder exists
-        await this.fsExtra.ensureDir(options.stagingFolderPath);
-        await this.copyToStaging(options.files, options.stagingFolderPath, options.rootDir);
-        return options.stagingFolderPath;
+        await this.fsExtra.ensureDir(options.stagingDir);
+        await this.copyToStaging(options.files, options.stagingDir, options.rootDir);
+        return options.stagingDir;
     }
 
     /**
@@ -111,16 +111,16 @@ export class RokuDeploy {
         let zipFilePath = this.getOutputZipFilePath(options);
 
         //ensure the manifest file exists in the staging folder
-        if (!await util.fileExistsCaseInsensitive(`${options.stagingFolderPath}/manifest`)) {
-            throw new Error(`Cannot zip package: missing manifest file in "${options.stagingFolderPath}"`);
+        if (!await util.fileExistsCaseInsensitive(`${options.stagingDir}/manifest`)) {
+            throw new Error(`Cannot zip package: missing manifest file in "${options.stagingDir}"`);
         }
 
         //create a zip of the staging folder
-        await this.zipFolder(options.stagingFolderPath, zipFilePath);
+        await this.zipFolder(options.stagingDir, zipFilePath);
 
         //delete the staging folder unless told to retain it.
-        if (options.retainStagingFolder !== true) {
-            await this.fsExtra.remove(options.stagingFolderPath);
+        if (options.retainStagingDir !== true) {
+            await this.fsExtra.remove(options.stagingDir);
         }
     }
 
@@ -133,7 +133,7 @@ export class RokuDeploy {
 
         await this.prepublishToStaging(options);
 
-        let manifestPath = util.standardizePath(`${options.stagingFolderPath}/manifest`);
+        let manifestPath = util.standardizePath(`${options.stagingDir}/manifest`);
         let parsedManifest = await this.parseManifest(manifestPath);
 
         if (options.incrementBuildNumber) {
@@ -145,7 +145,8 @@ export class RokuDeploy {
         if (beforeZipCallback) {
             let info: BeforeZipCallbackInfo = {
                 manifestData: parsedManifest,
-                stagingFolderPath: options.stagingFolderPath
+                stagingFolderPath: options.stagingDir,
+                stagingDir: options.stagingDir
             };
 
             await Promise.resolve(beforeZipCallback(info));
@@ -169,7 +170,6 @@ export class RokuDeploy {
     /**
     * Get all file paths for the specified options
     * @param files
-    * @param stagingFolderPath - the absolute path to the staging folder
     * @param rootFolderPath - the absolute path to the root dir where relative files entries are relative to
     */
     public async getFilePaths(files: FileEntry[], rootDir: string): Promise<StandardizedFileEntry[]> {
@@ -572,7 +572,7 @@ export class RokuDeploy {
         if (!options.signingPassword) {
             throw new errors.MissingRequiredOptionError('Must supply signingPassword');
         }
-        let manifestPath = path.join(options.stagingFolderPath, 'manifest');
+        let manifestPath = path.join(options.stagingDir, 'manifest');
         let parsedManifest = await this.parseManifest(manifestPath);
         let appName = parsedManifest.title + '/' + parsedManifest.major_version + '.' + parsedManifest.minor_version;
 
@@ -787,9 +787,9 @@ export class RokuDeploy {
      * @param options
      */
     public async deployAndSignPackage(options?: RokuDeployOptions, beforeZipCallback?: (info: BeforeZipCallbackInfo) => void): Promise<string> {
-        let originalOptionValueRetainStagingFolder = options.retainStagingFolder;
         options = this.getOptions(options);
-        options.retainStagingFolder = true;
+        let reainStagingDirInitialValue = options.retainStagingDir;
+        options.retainStagingDir = true;
         await this.deploy(options, beforeZipCallback);
 
         if (options.convertToSquashfs) {
@@ -798,8 +798,8 @@ export class RokuDeploy {
 
         let remotePkgPath = await this.signExistingPackage(options);
         let localPkgFilePath = await this.retrieveSignedPackage(remotePkgPath, options);
-        if (originalOptionValueRetainStagingFolder !== true) {
-            await this.fsExtra.remove(options.stagingFolderPath);
+        if (reainStagingDirInitialValue !== true) {
+            await this.fsExtra.remove(options.stagingDir);
         }
         return localPkgFilePath;
     }
@@ -842,7 +842,6 @@ export class RokuDeploy {
         let defaultOptions = <RokuDeployOptions>{
             outDir: './out',
             outFile: 'roku-deploy',
-            retainStagingFolder: false,
             retainDeploymentArchive: true,
             incrementBuildNumber: false,
             failOnCompileError: true,
@@ -863,12 +862,17 @@ export class RokuDeploy {
         //fully resolve the folder paths
         finalOptions.rootDir = path.resolve(process.cwd(), finalOptions.rootDir);
         finalOptions.outDir = path.resolve(process.cwd(), finalOptions.outDir);
+        finalOptions.retainStagingDir = (finalOptions.retainStagingDir !== undefined) ? finalOptions.retainStagingDir : finalOptions.retainStagingFolder;
+        delete finalOptions.retainStagingFolder;
 
-        //stagingFolderPath
-        if (finalOptions.stagingFolderPath) {
-            finalOptions.stagingFolderPath = path.resolve(process.cwd(), finalOptions.stagingFolderPath);
+        let stagingDir = finalOptions.stagingDir || finalOptions.stagingFolderPath;
+        delete finalOptions.stagingFolderPath;
+
+        //stagingDir
+        if (stagingDir) {
+            finalOptions.stagingDir = path.resolve(process.cwd(), stagingDir);
         } else {
-            finalOptions.stagingFolderPath = path.resolve(
+            finalOptions.stagingDir = path.resolve(
                 process.cwd(),
                 util.standardizePath(`${finalOptions.outDir}/.roku-deploy-staging`)
             );
@@ -1035,7 +1039,14 @@ export interface BeforeZipCallbackInfo {
      * Contains an associative array of the parsed values in the manifest
      */
     manifestData: ManifestData;
+    /**
+     * @deprecated since 3.8.2. use `stagingDir` instead
+     */
     stagingFolderPath: string;
+    /**
+     * The directory where the files were staged
+     */
+    stagingDir: string;
 }
 
 export interface StandardizedFileEntry {

--- a/src/RokuDeployOptions.ts
+++ b/src/RokuDeployOptions.ts
@@ -40,8 +40,15 @@ export interface RokuDeployOptions {
     /**
      * Set this to true to prevent the staging folder from being deleted after creating the package
      * @default false
+     * @deprecated use `retainStagingDir` instead
      */
     retainStagingFolder?: boolean;
+
+    /**
+     * Set this to true to prevent the staging folder from being deleted after creating the package
+     * @default false
+     */
+    retainStagingDir?: boolean;
 
     /**
      * Should the zipped package be retained after deploying to a roku. If false, this will delete the zip after a deployment.
@@ -51,8 +58,14 @@ export interface RokuDeployOptions {
 
     /**
      * The path where roku-deploy should stage all of the files right before being zipped. defaults to ${outDir}/.roku-deploy-staging
+     * @deprecated since 3.8.2. use `stagingDir` instead
      */
     stagingFolderPath?: string;
+
+    /**
+     * The path where roku-deploy should stage all of the files right before being zipped. defaults to ${outDir}/.roku-deploy-staging
+     */
+    stagingDir?: string;
 
     /**
      * The IP address or hostname of the target Roku device.


### PR DESCRIPTION
The `stagingFolderPath` and `stagingFolder` option names are verbose, and don't align with other options like `rootDir` and `outDir`. This PR adds two new properties, `stagingDir` and `retainStagingDir`. The old properties have now been deprecated but will continue to work until the next major release. 

- add `stagingDir` option
- add `retainStagingDir` option.
- Deprecate `stagingFolderPath` option.
- Deprecate `retainStagingFolder` option