### PR TITLE
Sync retainStagingFolder, stagingFolderPath with options.

### DIFF
--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -2906,7 +2906,7 @@ describe('index', () => {
             ).to.eql(s`${cwd}/staging-dir`);
             expect(
                 rokuDeploy.getOptions({ stagingFolderPath: 'staging-folder-path' }).stagingFolderPath
-            ).to.be.undefined;
+            ).to.eql(s`${cwd}/staging-dir`);
         });
 
         it('supports deprecated retainStagingFolder option', () => {
@@ -2921,7 +2921,7 @@ describe('index', () => {
             ).to.be.false;
             expect(
                 rokuDeploy.getOptions({ retainStagingFolder: true, retainStagingDir: false }).retainStagingFolder
-            ).to.be.undefined;
+            ).to.be.false;
         });
 
         it('calling with no parameters works', () => {

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -2906,7 +2906,7 @@ describe('index', () => {
             ).to.eql(s`${cwd}/staging-dir`);
             expect(
                 rokuDeploy.getOptions({ stagingFolderPath: 'staging-folder-path' }).stagingFolderPath
-            ).to.eql(s`${cwd}/staging-dir`);
+            ).to.eql(s`${cwd}/staging-folder-path`);
         });
 
         it('supports deprecated retainStagingFolder option', () => {

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -863,10 +863,10 @@ export class RokuDeploy {
         finalOptions.rootDir = path.resolve(process.cwd(), finalOptions.rootDir);
         finalOptions.outDir = path.resolve(process.cwd(), finalOptions.outDir);
         finalOptions.retainStagingDir = (finalOptions.retainStagingDir !== undefined) ? finalOptions.retainStagingDir : finalOptions.retainStagingFolder;
-        delete finalOptions.retainStagingFolder;
+        //sync the new option with the old one (for back-compat)
+        finalOptions.retainStagingFolder = finalOptions.retainStagingDir;
 
         let stagingDir = finalOptions.stagingDir || finalOptions.stagingFolderPath;
-        delete finalOptions.stagingFolderPath;
 
         //stagingDir
         if (stagingDir) {
@@ -877,6 +877,8 @@ export class RokuDeploy {
                 util.standardizePath(`${finalOptions.outDir}/.roku-deploy-staging`)
             );
         }
+        //sync the new option with the old one (for back-compat)
+        finalOptions.stagingFolderPath = finalOptions.stagingDir;
 
         return finalOptions;
     }


### PR DESCRIPTION
Fixes a critical backwards compatibility issue that was incorrectly deleting `stagingFolderPath` and `retainStagingFolder` after the transition to `stagingDir` and `retainStagingDir` in #99 