### PR TITLE
Replace minimatch with picomatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,9 @@
                 "is-glob": "^4.0.3",
                 "jsonc-parser": "^2.3.0",
                 "jszip": "^3.6.0",
-                "minimatch": "^3.0.4",
                 "moment": "^2.29.1",
                 "parse-ms": "^2.1.0",
+                "picomatch": "^2.2.1",
                 "request": "^2.88.0",
                 "temp-dir": "^2.0.0",
                 "xml2js": "^0.4.23"
@@ -1077,7 +1077,8 @@
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true
         },
         "node_modules/bcrypt-pbkdf": {
             "version": "1.0.2",
@@ -1100,6 +1101,7 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1330,7 +1332,8 @@
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
         },
         "node_modules/convert-source-map": {
             "version": "1.8.0",
@@ -3027,6 +3030,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -5517,7 +5521,8 @@
         "balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true
         },
         "bcrypt-pbkdf": {
             "version": "1.0.2",
@@ -5537,6 +5542,7 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -5714,7 +5720,8 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
         },
         "convert-source-map": {
             "version": "1.8.0",
@@ -6988,6 +6995,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "is-glob": "^4.0.3",
         "jsonc-parser": "^2.3.0",
         "jszip": "^3.6.0",
-        "minimatch": "^3.0.4",
+        "picomatch": "^2.2.1",
         "moment": "^2.29.1",
         "parse-ms": "^2.1.0",
         "request": "^2.88.0",


### PR DESCRIPTION
### SUMMARY

 - Remove `minimatch` dependency (no longer used)
 - Add `picomatch` dependency (matching version spec for mocha)

### DETAILS

When you install `roku-deploy` in pnpm workspaces in strict mode, you'll get errors at runtime because the source code uses `picomatch`, but that package isn't declared in the package json (it is transitively installed and hoisted by npm).

Here's my `npm why` output (should all bubble up to one install):

```console
picomatch@2.3.0
node_modules/picomatch
  picomatch@"^2.2.1" from the root project
  picomatch@"^2.0.4" from anymatch@3.1.2
  node_modules/anymatch
    anymatch@"~3.1.2" from chokidar@3.5.3
    node_modules/chokidar
      chokidar@"3.5.3" from mocha@9.2.2
      node_modules/mocha
        dev mocha@"^9.1.3" from the root project
  picomatch@"^2.2.3" from micromatch@4.0.4
  node_modules/micromatch
    micromatch@"^4.0.4" from fast-glob@3.2.11
    node_modules/fast-glob
      fast-glob@"^3.2.11" from the root project
      fast-glob@"^3.1.1" from globby@11.0.4
      node_modules/globby
        globby@"^11.0.4" from @typescript-eslint/typescript-estree@5.1.0
        node_modules/@typescript-eslint/typescript-estree
          @typescript-eslint/typescript-estree@"5.1.0" from @typescript-eslint/experimental-utils@5.1.0
          node_modules/@typescript-eslint/experimental-utils
            @typescript-eslint/experimental-utils@"5.1.0" from @typescript-eslint/eslint-plugin@5.1.0
            node_modules/@typescript-eslint/eslint-plugin
              dev @typescript-eslint/eslint-plugin@"5.1.0" from the root project
          @typescript-eslint/typescript-estree@"5.1.0" from @typescript-eslint/parser@5.1.0
          node_modules/@typescript-eslint/parser
            dev @typescript-eslint/parser@"5.1.0" from the root project
            peer @typescript-eslint/parser@"^5.0.0" from @typescript-eslint/eslint-plugin@5.1.0
            node_modules/@typescript-eslint/eslint-plugin
              dev @typescript-eslint/eslint-plugin@"5.1.0" from the root project
  picomatch@"^2.2.1" from readdirp@3.6.0
  node_modules/readdirp
    readdirp@"~3.6.0" from chokidar@3.5.3
    node_modules/chokidar
      chokidar@"3.5.3" from mocha@9.2.2
      node_modules/mocha
        dev mocha@"^9.1.3" from the root project
```

### TESTING

 - Fixes local error in pnpm workspace
 - Unit tests pass

