### PR TITLE
Fix bug that overwrites signing pkg during tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,11 @@
 name: build
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+  pull_request:
 
 jobs:
   ci:

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -29,7 +29,7 @@ describe('index', () => {
             stagingDir: stagingDir,
             signingPassword: '12345',
             host: 'localhost',
-            rekeySignedPackage: `../../testSignedPackage.pkg`
+            rekeySignedPackage: `${tempDir}/testSignedPackage.pkg`
         });
         options.rootDir = rootDir;
         fsExtra.emptyDirSync(tempDir);
@@ -911,7 +911,7 @@ describe('index', () => {
                 <keyed-developer-id>${options.devId}</keyed-developer-id>
             </device-info>`;
             mockDoGetRequest(body);
-            fsExtra.outputFileSync(`${rootDir}/${options.rekeySignedPackage}`, '');
+            fsExtra.outputFileSync(path.resolve(rootDir, options.rekeySignedPackage), '');
         });
 
         it('does not crash when archive is undefined', async () => {
@@ -931,7 +931,7 @@ describe('index', () => {
                 <font color="red">Success.</font>
             </div>`;
             mockDoPostRequest(body);
-            options.rekeySignedPackage = `../../testSignedPackage.pkg`;
+            options.rekeySignedPackage = s`${tempDir}/testSignedPackage.pkg`;
             await rokuDeploy.rekeyDevice(options);
         });
 
@@ -941,7 +941,7 @@ describe('index', () => {
             </div>`;
             mockDoPostRequest(body);
 
-            options.rekeySignedPackage = s`${cwd}/testSignedPackage.pkg`;
+            options.rekeySignedPackage = s`${tempDir}/testSignedPackage.pkg`;
             await rokuDeploy.rekeyDevice(options);
         });
 

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -931,8 +931,13 @@ describe('index', () => {
                 <font color="red">Success.</font>
             </div>`;
             mockDoPostRequest(body);
-            options.rekeySignedPackage = s`${tempDir}/testSignedPackage.pkg`;
-            await rokuDeploy.rekeyDevice(options);
+            options.rekeySignedPackage = s`../notReal.pkg`;
+            try {
+                fsExtra.writeFileSync(s`${tempDir}/notReal.pkg`, '');
+                await rokuDeploy.rekeyDevice(options);
+            } finally {
+                fsExtra.removeSync(s`${tempDir}/notReal.pkg`);
+            }
         });
 
         it('should work with absolute path', async () => {

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -555,7 +555,9 @@ describe('index', () => {
 
     it('runs via the command line using the rokudeploy.json file', function test() {
         this.timeout(20000);
-        child_process.execSync(`node dist/index.js`);
+        //build the project
+        child_process.execSync(`npm run build`, { stdio: 'inherit' });
+        child_process.execSync(`node dist/index.js`, { stdio: 'inherit' });
     });
 
     describe('generateBaseRequestOptions', () => {


### PR DESCRIPTION
Fixes a bug when running the roku-deploy unit test suite that accidentally overwrites the signingPackage.pkg file, by using tempDir instead in the tests.