### PR TITLE
TBD-67: roku-deploy: fix nodejs 19 bug

### DIFF
--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -382,7 +382,8 @@ export class RokuDeploy {
                 pass: options.password,
                 sendImmediately: false
             },
-            formData: formData
+            formData: formData,
+            agentOptions: { 'keepAlive': false }
         };
         return baseRequestOptions;
     }


### PR DESCRIPTION
'Request' module post requests fail with Nodejs v19 and up. To make it compatible with newer versions of node simply pass the following config values to the request apis to overcome socket error: agentOptions: { 'keepAlive': false }