### PR TITLE
Retry the convertToSquahsfs request given the HPE_INVALID_CONSTANT error

### DIFF
--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -1208,6 +1208,38 @@ describe('index', () => {
                 assert.fail('Should not have throw');
             }
         });
+
+        it('should fail with HTTP_INVALID_CONSTANT and then fail on retry', async () => {
+            let doPostStub = sinon.stub(rokuDeploy as any, 'doPostRequest');
+            doPostStub.onFirstCall().throws((params) => {
+                throw new HPE_INVALID_CONSTANT_ERROR();
+            });
+            doPostStub.onSecondCall().returns({ body: '..."fileType":"zip"...' });
+            try {
+                await rokuDeploy.convertToSquashfs(options);
+            } catch (e) {
+                expect(e).to.be.instanceof(errors.ConvertError);
+                return;
+            }
+            assert.fail('Should not have throw');
+        });
+
+        it('should fail with HTTP_INVALID_CONSTANT and then throw on retry', async () => {
+            let doPostStub = sinon.stub(rokuDeploy as any, 'doPostRequest');
+            doPostStub.onFirstCall().throws((params) => {
+                throw new HPE_INVALID_CONSTANT_ERROR();
+            });
+            doPostStub.onSecondCall().throws((params) => {
+                throw new Error('Never seen');
+            });
+            try {
+                await rokuDeploy.convertToSquashfs(options);
+            } catch (e) {
+                expect(e).to.be.instanceof(HPE_INVALID_CONSTANT_ERROR);
+                return;
+            }
+            assert.fail('Should not have throw');
+        });
     });
 
     class HPE_INVALID_CONSTANT_ERROR extends Error {

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -1196,6 +1196,20 @@ describe('index', () => {
             assert.fail('Should not have succeeded');
         });
 
+        it('should fail with thrown error', async () => {
+            let doPostStub = sinon.stub(rokuDeploy as any, 'doPostRequest');
+            doPostStub.onFirstCall().throws((params) => {
+                throw new Error('Some error');
+            });
+            try {
+                await rokuDeploy.convertToSquashfs(options);
+            } catch (e) {
+                expect(e).to.be.instanceof(Error);
+                return;
+            }
+            assert.fail('Should not have throw');
+        });
+
         it('should fail with HTTP_INVALID_CONSTANT and then succeed on retry', async () => {
             let doPostStub = sinon.stub(rokuDeploy as any, 'doPostRequest');
             doPostStub.onFirstCall().throws((params) => {

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -1195,7 +1195,24 @@ describe('index', () => {
             }
             assert.fail('Should not have succeeded');
         });
+
+        it('should fail with HTTP_INVALID_CONSTANT and then succeed on retry', async () => {
+            let doPostStub = sinon.stub(rokuDeploy as any, 'doPostRequest');
+            doPostStub.onFirstCall().throws((params) => {
+                throw new HPE_INVALID_CONSTANT_ERROR();
+            });
+            doPostStub.onSecondCall().returns({ body: '..."fileType":"squashfs"...' });
+            try {
+                await rokuDeploy.convertToSquashfs(options);
+            } catch (e) {
+                assert.fail('Should not have throw');
+            }
+        });
     });
+
+    class HPE_INVALID_CONSTANT_ERROR extends Error {
+        code = 'HPE_INVALID_CONSTANT';
+    }
 
     describe('rekeyDevice', () => {
         beforeEach(() => {

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -515,7 +515,7 @@ export class RokuDeploy {
             //wrong combination. The device fails to respond to our request with a valid response.
             //The device successfully converted the zip, so ping the device and and check the response
             //for "fileType": "squashfs" then return a happy response, otherwise throw the original error
-            if ((error as any)?.code === 'HPE_INVALID_CONSTANT') {
+            if ((error as any).code === 'HPE_INVALID_CONSTANT') {
                 try {
                     results = await this.doPostRequest(requestOptions, false);
                     if (/"fileType"\s*:\s*"squashfs"/.test(results.body)) {

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -511,6 +511,10 @@ export class RokuDeploy {
         try {
             results = await this.doPostRequest(requestOptions);
         } catch (error) {
+            //Occasionally this error is seen if the zip size and file name length at the
+            //wrong combination. The device fails to respond to our request with a valid response.
+            //The device successfully converted the zip, so ping the device and and check the response
+            //for "fileType": "squashfs" then return a happy response, otherwise throw the original error
             if ((error as any)?.code === 'HPE_INVALID_CONSTANT') {
                 try {
                     results = await this.doPostRequest(requestOptions, false);


### PR DESCRIPTION
We occasionally see the convertToSquashfs request fail. It seems determined by the size of the zip and the length of the file name. The Roku responds with half of the response body and roku-deploy cannot handle the bad data.

The squashfs conversion looks like it successfully created, the error is in the response.

The work around is to make a second request to squashfs when we see the 'HPE_INVALID_CONSTANT' error. If that response includes 'fileType': 'squashfs' then we return the result saying it succeeded.