### PR TITLE
Fix bug with absolute paths and getDestPath

### DIFF
--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -3018,6 +3018,19 @@ describe('index', () => {
     });
 
     describe('getDestPath', () => {
+        it('handles absolute paths properly', () => {
+            expect(
+                rokuDeploy.getDestPath(
+                    s`c:/projects/roku/local3/brighterscript/.tmp/rootDir/source/main.bs`,
+                    [{
+                        src: 'c:/projects/roku/local3/brighterscript/.tmp/rootDir/source/main.bs',
+                        dest: 'source/standalone.brs'
+                    }],
+                    'c:/projects/roku/local3/brighterscript/src/lsp/standalone-project-1'
+                )
+            ).to.equal(s`source/standalone.brs`);
+        });
+
         it('handles unrelated exclusions properly', () => {
             expect(
                 rokuDeploy.getDestPath(

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -228,13 +228,11 @@ export class RokuDeploy {
 
         function makeGlobAbsolute(pattern: string) {
             return path.resolve(
-                path.posix.join(
-                    rootDir,
-                    //remove leading exclamation point if pattern is negated
-                    pattern
-                    //coerce all slashes to forward
-                )
-            ).replace(/\\/g, '/');
+                rootDir,
+                //remove leading exclamation point if pattern is negated
+                pattern
+                //coerce all slashes to forward
+            ).replace(/\\+/g, '/');
         }
 
         let result: string;


### PR DESCRIPTION
Fixes an issue with `getDestPath` where it wouldn't work with certain absolute paths for the files array `src` prop