### PR TITLE
Fix issues with detecting "check for updates required"

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "publish-coverage": "nyc report --reporter=text-lcov | coveralls"
     },
     "dependencies": {
+        "@types/request": "^2.47.0",
         "chalk": "^2.4.2",
         "dateformat": "^3.0.3",
         "dayjs": "^1.11.0",
@@ -42,7 +43,6 @@
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.11.3",
         "@types/q": "^1.5.8",
-        "@types/request": "^2.47.0",
         "@types/sinon": "^10.0.4",
         "@types/xml2js": "^0.4.5",
         "@typescript-eslint/eslint-plugin": "5.1.0",

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -58,9 +58,11 @@ export class MissingRequiredOptionError extends Error {
 
 export class UpdateCheckRequiredError extends Error {
 
+    static MESSAGE = `Your device needs to check for updates before accepting connections. Please navigate to System Settings and check for updates and then try again.\n\nhttps://support.roku.com/article/208755668.`;
+
     constructor(response: HttpResponse) {
         super();
-        this.message = `Your device needs to check for updates before accepting connections. Please navigate to System Settings and check for updates and then try again.\n\nhttps://support.roku.com/article/208755668.`;
+        this.message = UpdateCheckRequiredError.MESSAGE;
         //this exact structure helps `roku-debug` detect this error by finding this status code and then showing a nice popup
         this.results = { response: { ...response ?? {}, statusCode: 500 } };
         Object.setPrototypeOf(this, UpdateCheckRequiredError.prototype);

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -1,4 +1,4 @@
-import type { RokuMessages } from './RokuDeploy';
+import type { HttpResponse, RokuMessages } from './RokuDeploy';
 
 export class InvalidDeviceResponseCodeError extends Error {
     constructor(message: string, public results?: any) {
@@ -57,15 +57,14 @@ export class MissingRequiredOptionError extends Error {
 }
 
 export class UpdateCheckRequiredError extends Error {
-    results: any;
 
-    cause: Error;
-
-    constructor(originalError: Error) {
+    constructor(response: HttpResponse) {
         super();
         this.message = `Your device needs to check for updates before accepting connections. Please navigate to System Settings and check for updates and then try again.\n\nhttps://support.roku.com/article/208755668.`;
-        this.results = { response: { statusCode: 577 } };
-        this.cause = originalError;
+        //this exact structure helps `roku-debug` detect this error by finding this status code and then showing a nice popup
+        this.results = { response: { ...response ?? {}, statusCode: 500 } };
         Object.setPrototypeOf(this, UpdateCheckRequiredError.prototype);
     }
+
+    results: any;
 }

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -3642,6 +3642,22 @@ https://support.roku.com/article/208755668.`));
         });
     });
 
+    describe('isUpdateCheckRequiredResponse', () => {
+        it('matches on actual response from device', () => {
+            const response = `<html>\n<head>\n  <meta charset=\"utf-8\">\n  <meta name=\"HandheldFriendly\" content=\"True\">\n  <title> Roku Development Kit </title>\n\n  <link rel=\"stylesheet\" type=\"text/css\" media=\"screen\" href=\"css/global.css\" />\n</head>\n<body>\n  <div id=\"root\" style=\"background: #fff\">\n\n  </div>\n\n  <script type=\"text/javascript\" src=\"css/global.js\"></script>\n  <script type=\"text/javascript\">\n  \n      // Include core components and resounce bundle (needed)\n      Shell.resource.set(null, {\n          endpoints: {} \n      });\n      Shell.create('Roku.Event.Key');\n      Shell.create('Roku.Events.Resize');\n      Shell.create('Roku.Events.Scroll');  \n      // Create global navigation and render it\n      var nav = Shell.create('Roku.Nav')\n        .trigger('Enable standalone and utility mode - hide user menu, shopping cart, and etc.')\n        .trigger('Use compact footer')\n        .trigger('Hide footer')\n        .trigger('Render', document.getElementById('root'))\n        .trigger('Remove all feature links from header')\n\n      // Retrieve main content body node\n      var node = nav.invoke('Get main body section mounting node');\n      \n      // Create page container and page header\n      var container = Shell.create('Roku.Nav.Page.Standard').trigger('Render', node);\n      node = container.invoke('Get main body node');\n      container.invoke('Get headline node').innerHTML = 'Failed to check for software update';\n\t  // Cannot reach Software Update Server\n      node.innerHTML = '<p>Please make sure that your Roku device is connected to internet and running most recent software.</p> <p> After connecting to internet, go to system settings and check for software update.</p> ';\n\n      var hrDiv = document.createElement('div');\n      hrDiv.innerHTML = '<hr />';\n      node.appendChild(hrDiv);\n\n      var d = document.createElement('div');\n      d.innerHTML = '<br />';\n      node.appendChild(d);\n\n  </script>\n\n\n  <div style=\"display:none\">\n\n  <font color=\"red\">Please make sure that your Roku device is connected to internet, and running most recent software version (d=953108)</font>\n\n  </div>\n\n</body>\n</html>\n`;
+            expect(
+                rokuDeploy['isUpdateCheckRequiredResponse'](response)
+            ).to.be.true;
+        });
+
+        it('matches with some variations to the message', () => {
+            const response = `"   FAILED    tocheck\tfor softwareupdate"`;
+            expect(
+                rokuDeploy['isUpdateCheckRequiredResponse'](response)
+            ).to.be.true;
+        });
+    });
+
     function mockDoGetRequest(body = '', statusCode = 200) {
         return sinon.stub(rokuDeploy as any, 'doGetRequest').callsFake((params) => {
             let results = { response: { statusCode: statusCode }, body: body };

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -1207,6 +1207,45 @@ describe('index', () => {
             }
             assert.fail('Should not have succeeded');
         });
+
+        it('Should throw an excpetion', async () => {
+            options.failOnCompileError = true;
+            mockDoPostRequest('', 577);
+
+            try {
+                await rokuDeploy.publish(options);
+            } catch (e) {
+                assert.ok('Exception was thrown as expected');
+                expect(e).to.be.instanceof(errors.UpdateCheckRequiredError);
+                return;
+            }
+            assert.fail('Should not have succeeded');
+        });
+
+        class ErrorWithConnectionResetCode extends Error {
+            code;
+
+            constructor(code = 'ECONNRESET') {
+                super();
+                this.code = code;
+            }
+        }
+
+        it('Should throw an excpetion', async () => {
+            options.failOnCompileError = true;
+            sinon.stub(rokuDeploy as any, 'doPostRequest').callsFake((params) => {
+                throw new ErrorWithConnectionResetCode();
+            });
+
+            try {
+                await rokuDeploy.publish(options);
+            } catch (e) {
+                assert.ok('Exception was thrown as expected');
+                expect(e).to.be.instanceof(errors.ConnectionResetError);
+                return;
+            }
+            assert.fail('Should not have succeeded');
+        });
     });
 
     describe('convertToSquashfs', () => {

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -1103,17 +1103,18 @@ describe('index', () => {
             });
         });
 
-        it('rejects when response contains invalid password status code', () => {
+        it('rejects when response contains invalid password status code', async () => {
             options.failOnCompileError = true;
-            mockDoPostRequest('', 577);
+            mockDoPostRequest(`'Failed to check for software update'`, 200);
 
-            return rokuDeploy.publish(options).then(() => {
+            try {
+                await rokuDeploy.publish(options);
                 assert.fail('Should not have succeeded due to roku server compilation failure');
-            }, (err) => {
-                expect(err.message).to.be.a('string').and.satisfy(msg => msg.startsWith(`Your device needs to check for updates before accepting connections. Please navigate to System Settings and check for updates and then try again.
-
-https://support.roku.com/article/208755668.`));
-            });
+            } catch (err) {
+                expect((err as any).message).to.eql(
+                    errors.UpdateCheckRequiredError.MESSAGE
+                );
+            }
         });
 
         it('handles successful deploy', () => {

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -475,7 +475,7 @@ export class RokuDeploy {
                 }
             } catch (e: any) {
                 //if this is a 577 error, we have high confidence that the device needs to do an update check
-                if (e?.results?.response?.statusCode === 577) {
+                if (e.results?.response?.statusCode === 577) {
                     throw new errors.UpdateCheckRequiredError(response, requestOptions, e);
 
                     //a reset connection could be cause by several things, but most likely it's due to the device needing to check for updates


### PR DESCRIPTION
Improves upon #180 . Apparently the device actually returns status code `200` instead of `577`. `577` is some other type of error, we should handle that separately.

This now checks for `200` responses to see if the exact text `'Failed to check for software update'` is found. If so, that's when we throw the `UpdateCheckRequiredError` error.