### PR TITLE
Add standards-compliant User-Agent header

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,8 +388,22 @@ Here are the available options. The defaults are shown to the right of the optio
     If true the previously installed dev channel will be deleted before installing the new one
 
 
-Click [here](https://github.com/rokucommunity/roku-deploy/blob/8e1cbdfcccb38dad4a1361277bdaf5484f1c2bcd/src/RokuDeploy.ts#L897) to see the typescript interface for these options
+Click [here](https://github.com/rokucommunity/roku-deploy/blob/master/src/RokuDeployOptions.ts) to see the typescript interface for these options
 
+
+## User-agent
+roku-deploy includes a User-Agent header to help you filter out unwanted network traffic from your network monitoring software of choice. The User-Agent header will be the name of the tool (`roku-deploy`) followed by the full version of the tool. If you're using a prerelease or temporary testing version, that information will also be included. Here are some examples:
+```
+User-Agent: roku-deploy/3.12.6
+User-Agent: roku-deploy/4.0.0-alpha.12
+User-Agent: roku-deploy/3.12.7-some-branch-name-123.3958293294854
+
+```
+
+If for some strange reason we were unable to find the version number, then the `User-Agent` will be:
+```
+User-Agent: roku-deploy/unknown
+```
 
 ## Troubleshooting
  - if you see a `ESOCKETTIMEDOUT` error during deployment, this can be caused by an antivirus blocking network traffic, so consider adding a special exclusion for your Roku device.

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -112,7 +112,7 @@ describe('index', () => {
                 return {} as any;
             });
 
-            let results = await rokuDeploy['doPostRequest']({}, true);
+            let results = await rokuDeploy['doPostRequest']({} as any, true);
             expect(results.body).to.equal(body);
         });
 
@@ -124,7 +124,7 @@ describe('index', () => {
             });
 
             try {
-                await rokuDeploy['doPostRequest']({}, true);
+                await rokuDeploy['doPostRequest']({} as any, true);
             } catch (e) {
                 expect(e).to.equal(error);
                 return;
@@ -140,7 +140,7 @@ describe('index', () => {
             });
 
             try {
-                await rokuDeploy['doPostRequest']({}, true);
+                await rokuDeploy['doPostRequest']({} as any, true);
             } catch (e) {
                 expect(e).to.be.instanceof(errors.InvalidDeviceResponseCodeError);
                 return;
@@ -155,7 +155,7 @@ describe('index', () => {
                 return {} as any;
             });
 
-            let results = await rokuDeploy['doPostRequest']({}, false);
+            let results = await rokuDeploy['doPostRequest']({} as any, false);
             expect(results.body).to.equal(body);
         });
     });
@@ -3755,6 +3755,72 @@ describe('index', () => {
         });
     });
 
+    describe('setUserAgentIfMissing', () => {
+        const currentVersion = fsExtra.readJsonSync(`${__dirname}/../package.json`).version;
+
+        it('getUserAgent caches package version', () => {
+            const spy = sinon.spy(fsExtra, 'readJsonSync');
+            rokuDeploy['_packageVersion'] = undefined;
+            expect(rokuDeploy['getUserAgent']()).to.eql(`roku-deploy/${currentVersion}`);
+            expect(rokuDeploy['getUserAgent']()).to.eql(`roku-deploy/${currentVersion}`);
+
+            expect(spy.callCount).to.equal(1);
+        });
+
+        it('getUserAgent caches failed package.json read', () => {
+            const stub = sinon.stub(fsExtra, 'readJsonSync').throws(new Error('Unable to read package.json'));
+            rokuDeploy['_packageVersion'] = undefined;
+            expect(rokuDeploy['getUserAgent']()).to.eql(`roku-deploy/unknown`);
+            expect(rokuDeploy['getUserAgent']()).to.eql(`roku-deploy/unknown`);
+
+            expect(stub.callCount).to.equal(1);
+            rokuDeploy['_packageVersion'] = null;
+        });
+
+        it('currentVersion is valid', () => {
+            expect(currentVersion).to.exist.and.to.match(/^\d+\.\d+\.\d+.*/);
+        });
+
+        it('works when params is undefined', () => {
+            //undefined
+            expect(
+                rokuDeploy['setUserAgentIfMissing'](undefined)
+            ).to.eql({ headers: { 'User-Agent': `roku-deploy/${currentVersion}` } });
+        });
+
+        it('works when params has no header container', () => {
+            expect(
+                rokuDeploy['setUserAgentIfMissing']({} as any)
+            ).to.eql({ headers: { 'User-Agent': `roku-deploy/${currentVersion}` } });
+        });
+
+        it('works when params has empty header container', () => {
+            expect(
+                rokuDeploy['setUserAgentIfMissing']({} as any)
+            ).to.eql({ headers: { 'User-Agent': `roku-deploy/${currentVersion}` } });
+        });
+
+        it('works when params has existing header container with no user agent', () => {
+            expect(
+                rokuDeploy['setUserAgentIfMissing']({ headers: {} } as any)
+            ).to.eql({ headers: { 'User-Agent': `roku-deploy/${currentVersion}` } });
+        });
+
+        it('works when params has existing header container with user agent', () => {
+            expect(
+                rokuDeploy['setUserAgentIfMissing']({ headers: { 'User-Agent': 'some-other-user-agent' } } as any)
+            ).to.eql({ headers: { 'User-Agent': 'some-other-user-agent' } });
+        });
+
+        it('works when we fail to load package version', () => {
+            sinon.stub(fsExtra, 'readJsonSync').throws(new Error('Unable to read package.json'));
+            rokuDeploy['_packageVersion'] = undefined;
+            expect(
+                rokuDeploy['setUserAgentIfMissing']({} as any)
+            ).to.eql({ headers: { 'User-Agent': 'roku-deploy/unknown' } });
+        });
+    });
+
     describe('isUpdateCheckRequiredResponse', () => {
         it('matches on actual response from device', () => {
             const response = `<html>\n<head>\n  <meta charset=\"utf-8\">\n  <meta name=\"HandheldFriendly\" content=\"True\">\n  <title> Roku Development Kit </title>\n\n  <link rel=\"stylesheet\" type=\"text/css\" media=\"screen\" href=\"css/global.css\" />\n</head>\n<body>\n  <div id=\"root\" style=\"background: #fff\">\n\n  </div>\n\n  <script type=\"text/javascript\" src=\"css/global.js\"></script>\n  <script type=\"text/javascript\">\n  \n      // Include core components and resounce bundle (needed)\n      Shell.resource.set(null, {\n          endpoints: {} \n      });\n      Shell.create('Roku.Event.Key');\n      Shell.create('Roku.Events.Resize');\n      Shell.create('Roku.Events.Scroll');  \n      // Create global navigation and render it\n      var nav = Shell.create('Roku.Nav')\n        .trigger('Enable standalone and utility mode - hide user menu, shopping cart, and etc.')\n        .trigger('Use compact footer')\n        .trigger('Hide footer')\n        .trigger('Render', document.getElementById('root'))\n        .trigger('Remove all feature links from header')\n\n      // Retrieve main content body node\n      var node = nav.invoke('Get main body section mounting node');\n      \n      // Create page container and page header\n      var container = Shell.create('Roku.Nav.Page.Standard').trigger('Render', node);\n      node = container.invoke('Get main body node');\n      container.invoke('Get headline node').innerHTML = 'Failed to check for software update';\n\t  // Cannot reach Software Update Server\n      node.innerHTML = '<p>Please make sure that your Roku device is connected to internet and running most recent software.</p> <p> After connecting to internet, go to system settings and check for software update.</p> ';\n\n      var hrDiv = document.createElement('div');\n      hrDiv.innerHTML = '<hr />';\n      node.appendChild(hrDiv);\n\n      var d = document.createElement('div');\n      d.innerHTML = '<br />';\n      node.appendChild(d);\n\n  </script>\n\n\n  <div style=\"display:none\">\n\n  <font color=\"red\">Please make sure that your Roku device is connected to internet, and running most recent software version (d=953108)</font>\n\n  </div>\n\n</body>\n</html>\n`;
@@ -3787,7 +3853,7 @@ describe('index', () => {
 
         it('returns false on missing results', () => {
             expect(
-                rokuDeploy['isUpdateRequiredError']({ })
+                rokuDeploy['isUpdateRequiredError']({})
             ).to.be.false;
         });
 


### PR DESCRIPTION
This PR accomplishes the following:
- include the User-Agent for every GET and POST request
- replace the [non-compliant user agent](https://github.com/rokucommunity/roku-deploy/blob/26e555d76baa757dfa1ce61beb86dbf73862cb1e/src/RokuDeploy.ts#L1089) with a compliant one. 

The User-Agent header is now the name of the tool (`roku-deploy/`) followed by the full version of the tool. If you're using a prerelease or temporary testing version of roku-deploy, that information will also be included. Here are some examples:
```
User-Agent: roku-deploy/3.12.6
User-Agent: roku-deploy/4.0.0-alpha.12
User-Agent: roku-deploy/3.12.7-some-branch-name-123.3958293294854

```

If for some strange reason we were unable to find the version number, then the `User-Agent` will be:
```
User-Agent: roku-deploy/unknown
```

Fixes #200 