### PR TITLE
fix: signed .pkg downloads are corrupted by utf8 decoding

### DIFF
--- a/src/request.spec.ts
+++ b/src/request.spec.ts
@@ -68,6 +68,18 @@ describe('request (needle shim)', () => {
             expect(postArgs.options.response_timeout).to.equal(12345);
         });
 
+        it('sets decode_response=false (Rokus label binary .pkg/screenshot downloads as text/plain)', async () => {
+            stubPost(null, { statusCode: 200, headers: {} }, 'ok');
+            await callPost({ url: 'http://1.2.3.4:80/plugin_install', formData: { a: 'b' } });
+            expect(postArgs.options.decode_response).to.equal(false);
+        });
+
+        it('sets decode_response=false on the streaming get used to download files', () => {
+            stubGet(null, undefined, undefined);
+            request.get({ url: 'http://1.2.3.4:80/pkgs/x.pkg' });
+            expect(getArgs.options.decode_response).to.equal(false);
+        });
+
         it('does NOT set read_timeout (its lingering re-armed timer leaks a handle in the digest-auth path)', async () => {
             stubPost(null, { statusCode: 200, headers: {} }, 'ok');
             await callPost({ url: 'http://1.2.3.4:80/plugin_install', timeout: 12345, formData: { a: 'b' } });

--- a/src/request.ts
+++ b/src/request.ts
@@ -135,6 +135,10 @@ export class Request {
         const needleOptions: needle.NeedleOptions = {
             //Roku responses are HTML/XML that roku-deploy parses by hand; never let needle auto-parse them
             parse_response: false,
+            //Rokus label binary downloads (.pkg, screenshots) `text/plain`, so needle would decode them as
+            //utf8 and replace every invalid byte with U+FFFD. `request` never decoded; keep bytes exact.
+            decode_response: false,
+
             //`request` had a single `timeout` that governed how long to wait to establish the connection and
             //receive a response. Map it to needle's `open_timeout` (connection) and `response_timeout` (time to
             //first response byte). Deliberately do NOT set `read_timeout`: needle's read-timer is re-armed on


### PR DESCRIPTION
# Summary

Signed `.pkg` downloads come back corrupt. Broke in 3.18.0, with the needle migration.

`translateOptions` never sets `decode_response`. Needle defaults it to `true`. So needle decodes binary bodies as text.
<details><summary>

## Context
</summary>

Rokus serve binary downloads as text:

```
HTTP/1.1 200 OK
Content-Type: text/plain
Content-Length: 2511264
```

No charset. Just `text/plain` on a 2.4MB binary.

Needle decodes when three things are true ([needle.js#L633](https://github.com/tomas/needle/blob/master/lib/needle.js#L633)):

```js
} else if (text_response && config.decode_response && mime.charset) {
```

Each one is true here:

- `text_response`: the header says `text/plain`
- `config.decode_response`: defaults to `true`, and we never set it
- `mime.charset`: needle falls back to `utf8` when the header has none

So the body goes through iconv-lite. Every byte that is not valid utf8 becomes U+FFFD (`ef bf bd`). One byte in, three bytes out. The file grows and the contents are garbage.

`postman-request` never decoded stream responses. That is why this is new in 3.18.0.

Note that `parse_response: false` does not cover this. It only gates the xml/json parsers, which sit on the branch above this one.

Same package, two ways to fetch it:

| | bytes at offset 0x20 | size |
|---|---|---|
| roku-deploy 3.18.2 | `0970 efbf bdef bfbd 1c5f` | 4553255 |
| `curl` | `0970 9abd 1c5f` | 2511264 |

The `.pkg` will not install.
</details><details>
<summary>

## Changes
</summary>

Set `decode_response: false` in `translateOptions`.

Roku responses are one of two things:

- text that roku-deploy parses by hand
- raw binary

Neither wants needle to decode it.

### Blast Radius

Code Changes:

- `src/request.ts`: add `decode_response: false` to `translateOptions`
- `src/request.spec.ts`: regression tests for the POST path and the streaming GET path

Blast Radius:

- `RokuDeploy.retrieveSignedPackage` and `deployAndSignPackage`
- `RokuDeploy.getDeviceScreenshot`
- Text responses do not change. They are already ASCII or utf8. `coerceBody` still decodes buffers to strings for callback consumers.

</details>

# Test Steps

1. Run `npm run build && npx mocha --require ts-node/register src/request.spec.ts`. All tests pass.
2. Revert the one-line fix. The two new tests fail. Nothing else does.
3. Run `deployAndSignPackage` against a real device. Fetch the same `pkgPath` with `curl`. Compare the two files:
   - the sizes match
   - the md5s match

   Before the fix, the roku-deploy copy is bigger than the `curl` copy and is littered with `ef bf bd` byte sequences.

