### PR TITLE
Support a raw POST body on sendEcpRequest

### DIFF
--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -835,6 +835,27 @@ describe('RokuDeploy', () => {
             expect(stub.getCall(0).args[0].url).to.equal('http://1.1.1.1:9060/keypress/Home');
         });
 
+        it('threads a raw POST body through to the request layer', async () => {
+            const stub = mockDoPostRequest();
+            const body = Buffer.from('raw-body-bytes');
+
+            await rokuDeploy.sendEcpRequest({ host: '1.1.1.1' }, 'some/route', { method: 'POST', body: body });
+
+            expect(stub.getCall(0).args[0].body).to.equal(body);
+        });
+
+        it('merges caller headers onto the request', async () => {
+            const stub = mockDoPostRequest();
+
+            await rokuDeploy.sendEcpRequest({ host: '1.1.1.1' }, 'some/route', {
+                method: 'POST',
+                body: 'raw',
+                headers: { 'Content-Type': 'application/octet-stream' }
+            });
+
+            expect(stub.getCall(0).args[0].headers).to.include({ 'Content-Type': 'application/octet-stream' });
+        });
+
         it('routes an RCE device through the instance ecp1 proxy with the X-Authorization bearer header', async () => {
             const stub = mockDoGetRequest('<sgrendezvous><status>OK</status></sgrendezvous>');
 

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -922,7 +922,12 @@ export class RokuDeploy {
         const response = await this.withRceInstanceUrlRetry(deviceConfig, async () => {
             instanceGoneResponse = undefined;
             const { baseUrl, headers } = await this.getEcpRequestBase(deviceConfig, ecpPort);
-            const requestOptions: RequestOptions = { url: `${baseUrl}/${route}`, timeout: timeout, headers: headers };
+            const requestOptions: RequestOptions = {
+                url: `${baseUrl}/${route}`,
+                timeout: timeout,
+                headers: { ...headers, ...options.headers },
+                body: options.body
+            };
             const result = options.method === 'POST'
                 ? await this.doPostRequest(requestOptions, verify)
                 : await this.doGetRequest(requestOptions, verify);
@@ -2771,6 +2776,10 @@ export interface BaseEcpOptions {
 export interface EcpOptions {
     /** The http method for the route; queries are GETs (the default), commands like keypress and launch are POSTs */
     method?: 'GET' | 'POST';
+    /** Raw POST body (string or Buffer), sent verbatim with no multipart framing. Ignored for GET requests. */
+    body?: string | Buffer;
+    /** Extra request headers to merge onto the request. */
+    headers?: Record<string, string>;
     /**
      * Run the standard response verification (throw on non-200 statuses and error bodies).
      * Defaults to false so raw ECP status bodies (a 202 `FAILED` registry response, for example)

--- a/src/request.spec.ts
+++ b/src/request.spec.ts
@@ -195,6 +195,55 @@ describe('request (needle shim)', () => {
         });
     });
 
+    describe('raw body translation', () => {
+        it('sends a string body verbatim without enabling multipart', async () => {
+            stubPost(null, { statusCode: 200, headers: {} }, 'ok');
+            await callPost({ url: 'http://1.2.3.4:8060/some/route', body: 'raw-body-string' });
+            expect(postArgs.data).to.equal('raw-body-string');
+            expect(postArgs.options.multipart).to.be.undefined;
+        });
+
+        it('sends a Buffer body verbatim without enabling multipart', async () => {
+            const buffer = Buffer.from([0x00, 0x01, 0x02, 0xFF]);
+            stubPost(null, { statusCode: 200, headers: {} }, 'ok');
+            await callPost({ url: 'http://1.2.3.4:8060/some/route', body: buffer });
+            expect(postArgs.data).to.equal(buffer);
+            expect(postArgs.options.multipart).to.be.undefined;
+        });
+
+        it('prefers a raw body over formData when both are set', async () => {
+            stubPost(null, { statusCode: 200, headers: {} }, 'ok');
+            await callPost({ url: 'http://1.2.3.4:80/x', body: 'raw', formData: { mysubmit: 'Replace' } });
+            expect(postArgs.data).to.equal('raw');
+            expect(postArgs.options.multipart).to.be.undefined;
+        });
+
+        it('preflights a bodied POST with credentials, sending the raw body only with the Authorization header', async () => {
+            const CHALLENGE = 'Digest qop="auth", realm="rokudev", nonce="abc123"';
+            const calls: Array<{ data: any; options: any }> = [];
+            sinon.stub(needle, 'post').callsFake(((url: string, data: any, options: any, callback: any) => {
+                const canned = calls.length === 0
+                    ? { response: { statusCode: 401, headers: { 'www-authenticate': CHALLENGE } }, body: Buffer.alloc(0) }
+                    : { response: { statusCode: 200, headers: {} }, body: 'ok' };
+                calls.push({ data: data, options: options });
+                process.nextTick(callback, null, canned.response, canned.body);
+                return {} as any;
+            }) as any);
+
+            await callPost({
+                url: 'http://1.2.3.4:80/some/route',
+                auth: { user: 'rokudev', pass: 'aaaa' },
+                body: 'raw-body'
+            });
+
+            expect(calls).to.have.lengthOf(2);
+            //the probe carries no body; the real request carries the raw body plus the computed digest header
+            expect(calls[0].data).to.be.null;
+            expect(calls[1].data).to.equal('raw-body');
+            expect(calls[1].options.headers.authorization).to.match(/^Digest /);
+        });
+    });
+
     describe('body coercion', () => {
         it('coerces a Buffer body to a string', async () => {
             stubPost(null, { statusCode: 200, headers: {} }, Buffer.from('hello world'));

--- a/src/request.ts
+++ b/src/request.ts
@@ -176,13 +176,18 @@ export class Request {
 
         let data: any = null;
         if (method === 'POST') {
-            const formData = this.translateFormData(params.formData);
-            //only send a multipart body when there's actually form data to send. Some POSTs (e.g. ECP
-            //keypress) have no body at all; needle's multipart builder throws "Empty multipart body" on an
-            //empty object, whereas `request` happily sent a bodyless POST. So fall back to a null body.
-            if (Object.keys(formData).length > 0) {
-                data = formData;
-                needleOptions.multipart = true;
+            //a raw body is written to the wire as-is (no multipart/urlencoding), for routes that read the raw request body
+            if (params.body !== undefined && params.body !== null) {
+                data = params.body;
+            } else {
+                const formData = this.translateFormData(params.formData);
+                //only send a multipart body when there's actually form data to send. Some POSTs (e.g. ECP
+                //keypress) have no body at all; needle's multipart builder throws "Empty multipart body" on an
+                //empty object, whereas `request` happily sent a bodyless POST. So fall back to a null body.
+                if (Object.keys(formData).length > 0) {
+                    data = formData;
+                    needleOptions.multipart = true;
+                }
             }
         }
 
@@ -424,6 +429,9 @@ export interface RequestOptions {
 
     /** multipart/form-data fields (string values, or a readable stream for the zip/pkg archive). */
     formData?: Record<string, any>;
+
+    /** Raw POST body (string or Buffer), sent verbatim with no multipart framing. Takes precedence over `formData`. */
+    body?: string | Buffer;
 
     /** Query-string object appended to the url. */
     qs?: Record<string, any>;


### PR DESCRIPTION
`sendEcpRequest` could only send a multipart/form-data POST body via `formData`. This adds an optional raw `body` (string or Buffer) sent verbatim, plus an optional `headers` merge, so ECP routes that read the raw request body can be reached through the generic transport.

- `EcpOptions` gains `body` and `headers`
- the request shim sends `body` verbatim on POST (no multipart framing), falling back to `formData` when unset
- the digest-auth preflight applies to a raw body too