### PR TITLE
feat: layered per-class timeouts (#353)

### DIFF
--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -7673,10 +7673,73 @@ describe('RokuDeploy', () => {
             });
         });
 
+        describe('timeouts (layered resolution)', () => {
+            it('does not bleed a long root timeout into ECP calls', async () => {
+                const rd = new RokuDeploy({ device: { host: 'localhost' }, timeout: 999999 });
+                const stub = sinon.stub(rd as any, 'doGetRequest').resolves({ response: { statusCode: 200 }, body: '' });
+                await rd.sendEcpRequest({ host: 'localhost' }, 'query/device-info');
+                expect(stub.getCall(0).args[0].timeout).to.equal(10000);
+            });
+
+            it('does not bleed timeouts.default into ECP calls (built-in class value outranks the root)', async () => {
+                const rd = new RokuDeploy({ device: { host: 'localhost' }, timeouts: { default: 777777 } });
+                const stub = sinon.stub(rd as any, 'doGetRequest').resolves({ response: { statusCode: 200 }, body: '' });
+                await rd.sendEcpRequest({ host: 'localhost' }, 'query/device-info');
+                expect(stub.getCall(0).args[0].timeout).to.equal(10000);
+            });
+
+            it('applies timeouts.ecp to ECP calls, and a per-call timeout still wins', async () => {
+                const rd = new RokuDeploy({ device: { host: 'localhost' }, timeouts: { ecp: 1234 } });
+                const stub = sinon.stub(rd as any, 'doGetRequest').resolves({ response: { statusCode: 200 }, body: '' });
+                await rd.sendEcpRequest({ host: 'localhost' }, 'query/device-info');
+                await rd.sendEcpRequest({ host: 'localhost' }, 'query/device-info', { timeout: 55 });
+                expect(stub.getCall(0).args[0].timeout).to.equal(1234);
+                expect(stub.getCall(1).args[0].timeout).to.equal(55);
+            });
+
+            it('applies timeouts.default to installer traffic, preferring it over the legacy timeout option', async () => {
+                const rd = new RokuDeploy({ timeouts: { default: 4321 }, timeout: 999 });
+                const result = await rd['generateBaseRequestOptions']('test', { host: 'localhost' }, { device: { host: 'localhost' }, password: 'test' });
+                expect(result.timeout).to.equal(4321);
+            });
+
+            it('applies the legacy timeout option to installer traffic when timeouts.default is absent', async () => {
+                const rd = new RokuDeploy({ timeout: 8888 });
+                const result = await rd['generateBaseRequestOptions']('test', { host: 'localhost' }, { device: { host: 'localhost' }, password: 'test' });
+                expect(result.timeout).to.equal(8888);
+            });
+
+            it('applies timeouts.rceManagement to the management client, defaulting to 30 seconds', () => {
+                const rd = new RokuDeploy({ timeouts: { rceManagement: 5555 } });
+                expect(rd['createRceManagementClient']('token')['timeout']).to.equal(5555);
+                expect(rokuDeploy['createRceManagementClient']('token')['timeout']).to.equal(30000);
+            });
+
+            it('rebootDevice uses the ecp timeout for its device-info check and the root timeout for the reboot post', async () => {
+                const rd = new RokuDeploy({ device: { host: 'localhost' }, password: 'p', timeout: 999999 });
+                const getStub = sinon.stub(rd as any, 'doGetRequest').resolves({ response: { statusCode: 200 }, body: '<device-info><software-version>15.0.4</software-version></device-info>' });
+                const postStub = sinon.stub(rd as any, 'doPostRequest').resolves({ response: { statusCode: 200 }, body: '' });
+                sinon.stub(util, 'dnsLookup').resolves('localhost');
+                await rd.rebootDevice({ device: { host: 'localhost' }, password: 'p' });
+                expect(getStub.getCall(0).args[0].timeout).to.equal(10000);
+                expect(postStub.getCall(0).args[0].timeout).to.equal(999999);
+            });
+
+            it('rebootDevice applies an explicit per-call timeout to both its requests', async () => {
+                const rd = new RokuDeploy({ device: { host: 'localhost' }, password: 'p' });
+                const getStub = sinon.stub(rd as any, 'doGetRequest').resolves({ response: { statusCode: 200 }, body: '<device-info><software-version>15.0.4</software-version></device-info>' });
+                const postStub = sinon.stub(rd as any, 'doPostRequest').resolves({ response: { statusCode: 200 }, body: '' });
+                sinon.stub(util, 'dnsLookup').resolves('localhost');
+                await rd.rebootDevice({ device: { host: 'localhost' }, password: 'p', timeout: 42 });
+                expect(getStub.getCall(0).args[0].timeout).to.equal(42);
+                expect(postStub.getCall(0).args[0].timeout).to.equal(42);
+            });
+        });
+
         describe('generateBaseRequestOptions', () => {
             it('uses default timeout', async () => {
                 const result = await rokuDeploy['generateBaseRequestOptions']('test', { host: 'localhost' }, { device: { host: 'localhost' }, password: 'test' });
-                expect(result.timeout).to.equal(RokuDeploy['defaults'].timeout);
+                expect(result.timeout).to.equal(RokuDeploy['defaults'].timeouts.default);
             });
 
             it('uses default packagePort', async () => {
@@ -7715,7 +7778,7 @@ describe('RokuDeploy', () => {
             it('uses default timeout', async () => {
                 const stub = sinon.stub(rokuDeploy as any, 'doPostRequest').resolves({});
                 await rokuDeploy['sendKeyEvent']({ device: { host: 'localhost' }, key: 'Home', action: 'keypress' });
-                expect(stub.getCall(0).args[0].timeout).to.equal(RokuDeploy['defaults'].ecpTimeout);
+                expect(stub.getCall(0).args[0].timeout).to.equal(RokuDeploy['defaults'].timeouts.ecp);
             });
 
             it('allows overriding ecpPort', async () => {
@@ -7745,7 +7808,7 @@ describe('RokuDeploy', () => {
                 } catch (e) {
                     // ignore parse errors
                 }
-                expect(stub.getCall(0).args[0].timeout).to.equal(RokuDeploy['defaults'].ecpTimeout);
+                expect(stub.getCall(0).args[0].timeout).to.equal(RokuDeploy['defaults'].timeouts.ecp);
             });
         });
 

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -63,17 +63,49 @@ export class RokuDeploy {
      * Default values for common options used across multiple functions
      */
     private static readonly defaults = {
-        timeout: 150000,
         /**
-         * The default timeout for ECP requests, in milliseconds. ECP commands are small and fast,
-         * so this is much lower than `timeout` (which must accommodate large installer uploads).
+         * Built-in timeouts (in milliseconds) per traffic class (see `resolveTimeout`)
          */
-        ecpTimeout: 10000,
+        timeouts: {
+            default: 150000,
+            ecp: 10000,
+            rceManagement: 30000
+        },
         packagePort: 80,
         ecpPort: 8060,
         outDir: './out',
         outFile: 'roku-deploy.zip'
     };
+
+    /**
+     * Resolve a request's timeout, most specific first: per-call, `timeouts.<group>`, built-in
+     * group value, `timeouts.default` (or legacy `timeout`), built-in default. A built-in group
+     * value deliberately outranks the root default so raising the root never slows fail-fast traffic.
+     */
+    private resolveTimeout(group: keyof typeof RokuDeploy.defaults.timeouts, perCallTimeout?: number): number {
+        if (perCallTimeout !== undefined) {
+            return perCallTimeout;
+        }
+        if (group === 'default') {
+            return this.options.timeouts?.default
+                ?? this.options.timeout
+                ?? RokuDeploy.defaults.timeouts.default;
+        }
+        return this.options.timeouts?.[group] ?? RokuDeploy.defaults.timeouts[group];
+    }
+
+    /**
+     * Merge constructor options into a per-call options object. The constructor `timeout` is
+     * excluded: only a caller-supplied timeout travels with the options, and the transports resolve
+     * the rest per traffic class (see `resolveTimeout`).
+     */
+    private mergeOptions<T extends { timeout?: number }>(options: T): T {
+        const merged = { ...this.options, ...options } as T;
+        if (options?.timeout === undefined) {
+            delete merged.timeout;
+        }
+        return merged;
+    }
 
     /**
      * Network error codes that mean the request never reached a live endpoint (host gone,
@@ -193,7 +225,7 @@ export class RokuDeploy {
      * @param options
      */
     public async sideload(options: SideloadOptions): Promise<{ message: string; results: any }> {
-        options = { ...this.options, ...options } as SideloadOptions;
+        options = this.mergeOptions(options);
         this.logger.info('Beginning to sideload package');
         this.checkRequiredOptions(options, ['device', 'password']);
         this.validatePort(options.packagePort, 'packagePort');
@@ -375,7 +407,7 @@ export class RokuDeploy {
      * @param options
      */
     public async convertToSquashfs(options: ConvertToSquashfsOptions) {
-        options = { ...this.options, ...options } as ConvertToSquashfsOptions;
+        options = this.mergeOptions(options);
         this.checkRequiredOptions(options, ['device', 'password']);
         this.validatePort(options.packagePort, 'packagePort');
         this.validateTimeout(options.timeout);
@@ -426,7 +458,7 @@ export class RokuDeploy {
      * @param options
      */
     public async createSignedPackage(options: CreateSignedPackageOptions): Promise<CreateSignedPackageResult> {
-        options = { ...this.options, ...options } as CreateSignedPackageOptions;
+        options = this.mergeOptions(options);
         this.logger.info('Creating signed package');
         this.checkRequiredOptions(options, ['device', 'password', 'signingPassword']);
         this.validatePort(options.packagePort, 'packagePort');
@@ -521,7 +553,7 @@ export class RokuDeploy {
      * @param options
      */
     public async rekeyDevice(options: RekeyDeviceOptions) {
-        options = { ...this.options, ...options } as RekeyDeviceOptions;
+        options = this.mergeOptions(options);
         this.checkRequiredOptions(options, ['device', 'password', 'pkg', 'signingPassword']);
         this.validatePort(options.packagePort, 'packagePort');
         this.validateTimeout(options.timeout);
@@ -594,7 +626,7 @@ export class RokuDeploy {
     public async getDeviceInfo(options?: GetDeviceInfoOptions & { enhance: true }): Promise<DeviceInfo>;
     public async getDeviceInfo(options?: GetDeviceInfoOptions): Promise<DeviceInfoRaw>;
     public async getDeviceInfo(options: GetDeviceInfoOptions) {
-        options = { ...this.options, ...options } as GetDeviceInfoOptions;
+        options = this.mergeOptions(options);
         this.checkRequiredOptions(options, ['device']);
 
         let result: EcpResult;
@@ -654,7 +686,7 @@ export class RokuDeploy {
      *   - 'permissive': Full access for internal networks
      */
     public async getEcpNetworkAccessMode(options: GetDeviceInfoOptions): Promise<EcpNetworkAccessMode> {
-        options = { ...this.options, ...options } as GetDeviceInfoOptions;
+        options = this.mergeOptions(options);
         try {
             const deviceInfo = await this.getDeviceInfo(options);
             return deviceInfo['ecp-setting-mode'];
@@ -672,7 +704,7 @@ export class RokuDeploy {
      * @returns
      */
     public async getDevId(options?: GetDevIdOptions): Promise<GetDevIdResult> {
-        options = { ...this.options, ...options } as GetDevIdOptions;
+        options = this.mergeOptions(options);
         this.checkRequiredOptions(options, ['device']);
         const deviceInfo = await this.getDeviceInfo(options);
         this.logger.debug('Found dev id:', deviceInfo['keyed-developer-id']);
@@ -685,7 +717,7 @@ export class RokuDeploy {
      */
 
     public async captureScreenshot(options: CaptureScreenshotOptions): Promise<CaptureScreenshotResult> {
-        options = { ...this.options, ...options } as CaptureScreenshotOptions;
+        options = this.mergeOptions(options);
         this.checkRequiredOptions(options, ['device', 'password']);
         this.validatePort(options.packagePort, 'packagePort');
         this.validateTimeout(options.timeout);
@@ -757,7 +789,7 @@ export class RokuDeploy {
     }
 
     public async rebootDevice(options: RebootDeviceOptions) {
-        options = { ...this.options, ...options } as RebootDeviceOptions;
+        options = this.mergeOptions(options);
         this.checkRequiredOptions(options, ['device', 'password']);
 
         const deviceConfig = this.resolveDevice(options.device);
@@ -790,7 +822,7 @@ export class RokuDeploy {
     }
 
     public async checkForUpdate(options: CheckForUpdateOptions) {
-        options = { ...this.options, ...options } as CheckForUpdateOptions;
+        options = this.mergeOptions(options);
         this.checkRequiredOptions(options, ['device', 'password']);
 
         const deviceConfig = this.resolveDevice(options.device);
@@ -906,12 +938,12 @@ export class RokuDeploy {
      *                chanperf response, for example) come back to the caller instead of throwing.
      */
     public async sendEcpRequest(device: DeviceOption, route: string, options?: EcpOptions): Promise<EcpResult> {
-        options = { ...this.options, ...options } as EcpOptions;
+        options = this.mergeOptions(options);
         this.validatePort(options.ecpPort, 'ecpPort');
         this.validateTimeout(options.timeout);
 
         const deviceConfig = this.resolveDevice(device);
-        const timeout = options.timeout ?? RokuDeploy.defaults.ecpTimeout;
+        const timeout = this.resolveTimeout('ecp', options.timeout);
         const ecpPort = options.ecpPort ?? RokuDeploy.defaults.ecpPort;
 
         const verify = options.verify ?? false;
@@ -948,7 +980,7 @@ export class RokuDeploy {
     }
 
     public async keyPress(options: KeyPressOptions) {
-        options = { ...this.options, ...options } as KeyPressOptions;
+        options = this.mergeOptions(options);
         return this.sendKeyEvent({
             ...options,
             key: options.key,
@@ -957,7 +989,7 @@ export class RokuDeploy {
     }
 
     public async keyDown(options: KeyDownOptions) {
-        options = { ...this.options, ...options } as KeyDownOptions;
+        options = this.mergeOptions(options);
         return this.sendKeyEvent({
             ...options,
             action: 'keydown'
@@ -965,7 +997,7 @@ export class RokuDeploy {
     }
 
     public async keyUp(options: KeyUpOptions) {
-        options = { ...this.options, ...options } as KeyUpOptions;
+        options = this.mergeOptions(options);
         return this.sendKeyEvent({
             ...options,
             action: 'keyup'
@@ -973,7 +1005,7 @@ export class RokuDeploy {
     }
 
     public async sendText(options: SendTextOptions) {
-        options = { ...this.options, ...options } as SendTextOptions;
+        options = this.mergeOptions(options);
         this.checkRequiredOptions(options, ['device', 'text']);
         const chars = options.text.split('');
         for (const char of chars) {
@@ -993,7 +1025,7 @@ export class RokuDeploy {
      * failing key and step.
      */
     public async sendKeySequence(options: SendKeySequenceOptions): Promise<void> {
-        options = { ...this.options, ...options } as SendKeySequenceOptions;
+        options = this.mergeOptions(options);
         this.checkRequiredOptions(options, ['device', 'keys']);
         const keyDelayMs = options.keyDelayMs ?? 250;
         for (let stepIndex = 0; stepIndex < options.keys.length; stepIndex++) {
@@ -1021,7 +1053,7 @@ export class RokuDeploy {
      * endpoint only exists on the RCE instance api.
      */
     public async sendDeveloperSettingsCombo(options: SendDeveloperSettingsComboOptions): Promise<void> {
-        options = { ...this.options, ...options } as SendDeveloperSettingsComboOptions;
+        options = this.mergeOptions(options);
         this.checkRequiredOptions(options, ['device']);
         const deviceConfig = this.resolveDevice(options.device);
         if (!isRceDeviceConfig(deviceConfig)) {
@@ -1035,7 +1067,7 @@ export class RokuDeploy {
             const instanceUrl = await this.getRceInstanceUrl(deviceConfig);
             return this.doPostRequest({
                 url: `${instanceUrl}/api/v0/xi/developer-settings-combo`,
-                timeout: options.timeout ?? RokuDeploy.defaults.ecpTimeout,
+                timeout: this.resolveTimeout('ecp', options.timeout),
                 headers: this.buildRceAuthHeaders(rceToken)
             }, true);
         });
@@ -1046,7 +1078,7 @@ export class RokuDeploy {
      * @param options
      */
     public async launchApp(options: LaunchAppOptions): Promise<void> {
-        options = { ...this.options, ...options } as LaunchAppOptions;
+        options = this.mergeOptions(options);
         this.checkRequiredOptions(options, ['device', 'appId']);
 
         const queryString = this.buildLaunchQueryString(options);
@@ -1063,7 +1095,7 @@ export class RokuDeploy {
      * @param options
      */
     public async exitApp(options: ExitAppOptions): Promise<void> {
-        options = { ...this.options, ...options } as ExitAppOptions;
+        options = this.mergeOptions(options);
         this.checkRequiredOptions(options, ['device', 'appId']);
 
         const forceSegment = options.force ? '/true' : '';
@@ -1086,7 +1118,7 @@ export class RokuDeploy {
     }
 
     public async closeChannel(options: CloseChannelOptions) {
-        options = { ...this.options, ...options } as CloseChannelOptions;
+        options = this.mergeOptions(options);
         // TODO: After 13.0 releases, add check for ECP close-app support, and use that twice to kill instant resume if available
         await this.sendKeyEvent({
             ...options,
@@ -1100,7 +1132,7 @@ export class RokuDeploy {
      * @param options
      */
     public async queryApps(options: QueryAppsOptions): Promise<RokuAppDescriptor[]> {
-        options = { ...this.options, ...options } as QueryAppsOptions;
+        options = this.mergeOptions(options);
         this.checkRequiredOptions(options, ['device']);
 
         let result: EcpResult;
@@ -1140,7 +1172,7 @@ export class RokuDeploy {
      * @param options
      */
     public async queryActiveApp(options: QueryActiveAppOptions): Promise<RokuActiveApp> {
-        options = { ...this.options, ...options } as QueryActiveAppOptions;
+        options = this.mergeOptions(options);
         this.checkRequiredOptions(options, ['device']);
 
         let result: EcpResult;
@@ -1171,7 +1203,7 @@ export class RokuDeploy {
      * @param options
      */
     public async queryRegistry(options: QueryRegistryOptions): Promise<RokuRegistry> {
-        options = { ...this.options, ...options } as QueryRegistryOptions;
+        options = this.mergeOptions(options);
         this.checkRequiredOptions(options, ['device', 'appId']);
 
         const result = await this.sendEcpRequest(options.device, `query/registry/${encodeURIComponent(options.appId)}`, {
@@ -1209,7 +1241,7 @@ export class RokuDeploy {
      * @param options
      */
     public async queryAppState(options: QueryAppStateOptions): Promise<RokuAppState> {
-        options = { ...this.options, ...options } as QueryAppStateOptions;
+        options = this.mergeOptions(options);
         this.checkRequiredOptions(options, ['device', 'appId']);
 
         const result = await this.sendEcpRequest(options.device, `query/app-state/${encodeURIComponent(options.appId)}`, {
@@ -1236,7 +1268,7 @@ export class RokuDeploy {
      * @param options
      */
     public async queryRendezvous(options: QueryRendezvousOptions): Promise<RokuRendezvous> {
-        options = { ...this.options, ...options } as QueryRendezvousOptions;
+        options = this.mergeOptions(options);
         this.checkRequiredOptions(options, ['device']);
 
         const result = await this.sendEcpRequest(options.device, 'query/sgrendezvous', {
@@ -1264,7 +1296,7 @@ export class RokuDeploy {
      * @param options
      */
     public async setRendezvousTracking(options: SetRendezvousTrackingOptions): Promise<boolean> {
-        options = { ...this.options, ...options } as SetRendezvousTrackingOptions;
+        options = this.mergeOptions(options);
         this.checkRequiredOptions(options, ['device', 'enabled']);
 
         const result = await this.sendEcpRequest(options.device, `sgrendezvous/${options.enabled ? 'track' : 'untrack'}`, {
@@ -1281,7 +1313,7 @@ export class RokuDeploy {
      * @param options
      */
     public async deleteDevChannel(options?: DeleteDevChannelOptions) {
-        options = { ...this.options, ...options } as DeleteDevChannelOptions;
+        options = this.mergeOptions(options);
         this.logger.info('Deleting dev channel...');
         this.checkRequiredOptions(options, ['device', 'password']);
         this.validatePort(options.packagePort, 'packagePort');
@@ -1304,7 +1336,7 @@ export class RokuDeploy {
      * @param options
      */
     public async deleteAllSideloadedPlugins(options?: DeleteDevChannelOptions) {
-        options = { ...this.options, ...options } as DeleteDevChannelOptions;
+        options = this.mergeOptions(options);
         this.checkRequiredOptions(options, ['device', 'password']);
 
         const deviceConfig = this.resolveDevice(options.device);
@@ -1323,7 +1355,7 @@ export class RokuDeploy {
      * Delete the component library with the specified filename from the device
      */
     public async deleteComponentLibrary(options?: DeleteComponentLibraryOptions) {
-        options = { ...this.options, ...options } as DeleteComponentLibraryOptions;
+        options = this.mergeOptions(options);
         this.checkRequiredOptions(options, ['device', 'password', 'fileName']);
 
         const deviceConfig = this.resolveDevice(options.device);
@@ -1346,7 +1378,7 @@ export class RokuDeploy {
      * Delete all component libraries from the device
      */
     public async deleteAllComponentLibraries(options: DeleteAllComponentLibrariesOptions) {
-        options = { ...this.options, ...options } as DeleteAllComponentLibrariesOptions;
+        options = this.mergeOptions(options);
         const packages = await this.listSideloadedPlugins(options);
         for (const pkg of packages) {
             if (pkg.appType === 'dcl') {
@@ -1363,7 +1395,7 @@ export class RokuDeploy {
      * file names of installed component libraries or the dev channel.
      */
     public async listSideloadedPlugins(options: ListSideloadedPluginsOptions): Promise<RokuPlugin[]> {
-        options = { ...this.options, ...options } as ListSideloadedPluginsOptions;
+        options = this.mergeOptions(options);
         this.checkRequiredOptions(options, ['device', 'password']);
 
         const deviceConfig = this.resolveDevice(options.device);
@@ -1536,7 +1568,7 @@ export class RokuDeploy {
         const mergedOptions = { ...this.options, ...options };
         // Set defaults for request options
         const packagePort = mergedOptions.packagePort ?? RokuDeploy.defaults.packagePort;
-        const timeout = mergedOptions.timeout ?? RokuDeploy.defaults.timeout;
+        const timeout = this.resolveTimeout('default', options.timeout);
         const username = mergedOptions.username ?? 'rokudev';
 
         const { baseUrl, headers } = await this.getInstallerRequestBase(deviceConfig, packagePort);
@@ -1845,7 +1877,7 @@ export class RokuDeploy {
      * instance URL. Split out so tests can supply a fake.
      */
     private createRceManagementClient(rceToken: string): RceManagementClient {
-        return new RceManagementClient({ token: rceToken });
+        return new RceManagementClient({ token: rceToken, timeout: this.resolveTimeout('rceManagement') });
     }
 
     /**
@@ -1984,7 +2016,7 @@ export class RokuDeploy {
      * normal sendEcpRequest() transport below, so RCE devices in normal mode and LAN devices are unaffected.
      */
     private async sendKeyEvent(options: SendKeyEventOptions) {
-        options = { ...this.options, ...options };
+        options = this.mergeOptions(options);
         this.logger.info('Sending key event:', options.key);
         this.checkRequiredOptions(options, ['device', 'key']);
 
@@ -1999,7 +2031,7 @@ export class RokuDeploy {
                 const response = await this.withRceInstanceUrlRetry(deviceConfig, async () => {
                     const instanceUrl = await this.getRceInstanceUrl(deviceConfig);
                     const url = `${instanceUrl}/api/v0/ecp1/${options.action}/${key}`;
-                    return this.doPostRequest({ url: url, timeout: options.timeout ?? RokuDeploy.defaults.ecpTimeout, headers: this.buildRceAuthHeaders(rceToken) }, true);
+                    return this.doPostRequest({ url: url, timeout: this.resolveTimeout('ecp', options.timeout), headers: this.buildRceAuthHeaders(rceToken) }, true);
                 });
                 return {
                     status: response?.response?.statusCode,

--- a/src/RokuDeployOptions.ts
+++ b/src/RokuDeployOptions.ts
@@ -64,13 +64,39 @@ export interface RokuDeployConstructorOptions {
     ecpPort?: number;
     /**
      * The request timeout duration in milliseconds. Defaults to 150000ms (2 minutes 30 seconds).
+     * Shorthand for `timeouts.default`; use `timeouts` to target a specific traffic class.
      */
     timeout?: number;
+    /**
+     * Timeouts (in milliseconds) per traffic class, each falling back to the built-in value for its
+     * class when omitted. A timeout supplied on an individual method call always wins.
+     */
+    timeouts?: RokuDeployTimeouts;
     /**
      * The default RCE bearer token for Roku Cloud Emulator devices whose config carries no
      * rceToken of its own. A config-supplied rceToken always wins over this default.
      */
     rceToken?: string;
+}
+
+/**
+ * Timeouts (in milliseconds) per traffic class. Resolution, most specific first: per-call
+ * `timeout`, `timeouts.<class>`, the built-in class default, `timeouts.default` (or the legacy
+ * `timeout` option). A class default outranks `default` so raising it never slows fail-fast traffic.
+ */
+export interface RokuDeployTimeouts {
+    /**
+     * Installer traffic (sideload, package, screenshot, ...). Defaults to 150000.
+     */
+    default?: number;
+    /**
+     * ECP traffic (key presses, queries, launch/exit). Defaults to 10000.
+     */
+    ecp?: number;
+    /**
+     * Roku Cloud Emulator management api traffic. Defaults to 30000.
+     */
+    rceManagement?: number;
 }
 
 export interface RokuDeployOptions {
@@ -168,8 +194,15 @@ export interface RokuDeployOptions {
      * The request timeout duration in milliseconds. Defaults to 150000ms (2 minutes 30 seconds).
      * This is mainly useful for preventing hang ups if the Roku loses power or restarts due to a firmware bug.
      * This is applied per network request to the device and does not apply to the total time it takes to completely execute a call to roku-deploy.
+     * Shorthand for `timeouts.default`; use `timeouts` to target a specific traffic class.
      */
     timeout?: number;
+
+    /**
+     * Timeouts (in milliseconds) per traffic class, each falling back to the built-in value for its
+     * class when omitted. A timeout supplied on an individual method call always wins.
+     */
+    timeouts?: RokuDeployTimeouts;
 
     /**
      * The username for the roku box. This will always be 'rokudev', but allows to be overridden


### PR DESCRIPTION
Fixes #353

Adds a `timeouts` option (`{ default, ecp, rceManagement }`) so each traffic class gets its own timeout. Resolution, most specific first: per-call `timeout` → `timeouts.<class>` → built-in class default (ecp 10s, rceManagement 30s) → `timeouts.default` / legacy `timeout` → 150s. Class defaults outrank the root on purpose — raising the root for slow uploads shouldn't slow fail-fast ECP traffic.

Also fixes the constructor `timeout` bleeding into ECP calls (directly, and via sideload/rebootDevice/checkForUpdate's nested ECP requests).