### PR TITLE
Refine comments

### DIFF
--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -22,7 +22,7 @@ export enum RokuDeployErrorCode {
 }
 
 /**
- * HTTP request details, independent of the underlying HTTP library
+ * HTTP request details
  */
 export interface HttpRequestDetails {
     url?: string;
@@ -32,7 +32,7 @@ export interface HttpRequestDetails {
 }
 
 /**
- * HTTP response details, independent of the underlying HTTP library
+ * HTTP response details
  */
 export interface HttpResponseDetails {
     statusCode?: number;

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -22,7 +22,8 @@ export enum RokuDeployErrorCode {
 }
 
 /**
- * HTTP request details
+ * HTTP request details, abstracted from the underlying HTTP library so it can be swapped without
+ * breaking consumers
  */
 export interface HttpRequestDetails {
     url?: string;
@@ -32,7 +33,8 @@ export interface HttpRequestDetails {
 }
 
 /**
- * HTTP response details
+ * HTTP response details, abstracted from the underlying HTTP library so it can be swapped without
+ * breaking consumers
  */
 export interface HttpResponseDetails {
     statusCode?: number;

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -22,8 +22,7 @@ export enum RokuDeployErrorCode {
 }
 
 /**
- * Abstracted HTTP request details - NOT tied to request library.
- * This allows switching from postman-request to native fetch later.
+ * HTTP request details, independent of the underlying HTTP library
  */
 export interface HttpRequestDetails {
     url?: string;
@@ -33,8 +32,7 @@ export interface HttpRequestDetails {
 }
 
 /**
- * Abstracted HTTP response details - NOT tied to request library.
- * This allows switching from postman-request to native fetch later.
+ * HTTP response details, independent of the underlying HTTP library
  */
 export interface HttpResponseDetails {
     statusCode?: number;
@@ -435,8 +433,7 @@ export function isUnsupportedFirmwareVersionError(e: unknown): e is UnsupportedF
 // ============================================================================
 
 /**
- * Extract HttpDetails from a request library response.
- * This abstracts the response format so we can switch HTTP libraries later.
+ * Extract HttpDetails from a request library response
  */
 export function extractHttpDetails(
     response: { statusCode?: number; headers?: Record<string, string>; request?: { uri?: { href?: string }; method?: string; headers?: Record<string, string> } } | undefined,

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -1,19 +1,12 @@
 /**
- * Backwards-compatibility shim.
+ * Backwards-compatibility shim: roku-deploy 3.18.0 migrated logging to `@rokucommunity/logger` and
+ * deleted this module, breaking consumers that deep-import `roku-deploy/dist/Logger` (most notably
+ * brighterscript's `ProgramBuilder`). This restores that import path by re-exporting the equivalents:
+ * `LogLevel` is `LogLevelNumeric` (same member names and numeric values as the old enum) and
+ * `Logger` is the `Logger` class (same core surface).
  *
- * roku-deploy 3.18.0 migrated its logging to `@rokucommunity/logger` and deleted this module, which broke
- * consumers that deep-import `roku-deploy/dist/Logger` (most notably brighterscript's `ProgramBuilder`).
- * This module restores that import path by re-exporting the equivalents from `@rokucommunity/logger`:
- *
- * - `LogLevel` here is `@rokucommunity/logger`'s `LogLevelNumeric`, which has the exact same member names
- *   and numeric values (off=0 through trace=6) as the enum that used to live in this file. Because it is
- *   the same declaration used by `RokuDeployOptions['logLevel']`, values of this type remain assignable
- *   everywhere the old enum was accepted.
- * - `Logger` is `@rokucommunity/logger`'s `Logger` class, which carries the same core surface the old
- *   class had (`logLevel` get/set, `error`/`warn`/`log`/`info`/`debug`/`trace`, and `time`).
- *
- * @deprecated import from '@rokucommunity/logger' instead. This module exists only so older consumers
- * keep compiling and will be removed in the next major version.
+ * @deprecated import from '@rokucommunity/logger' instead. This module exists only so older
+ * consumers keep compiling and will be removed in the next major version.
  */
 
 /** @deprecated use `LogLevelNumeric` from '@rokucommunity/logger' instead */

--- a/src/RceManagementClient.ts
+++ b/src/RceManagementClient.ts
@@ -4,9 +4,8 @@ import type { RceDeviceConfig } from './DeviceConfig';
 import { isRceDeviceConfigById, isRceDeviceConfigByUrl } from './DeviceConfig';
 
 /**
- * Default base URL for the Roku Cloud Emulator (RCE) management API. This is the core management
- * surface (device inventory, lifecycle, snapshots, firmware, usage) and is distinct from a running
- * device's own instance API. It is authenticated with an RCE bearer token.
+ * Default base URL for the Roku Cloud Emulator (RCE) management API (distinct from a running
+ * device's own instance API).
  */
 export const defaultRceManagementBaseUrl = 'https://api.rce.roku.com/api/v1';
 
@@ -70,8 +69,8 @@ export class RceManagementClient {
     }
 
     /**
-     * Boot a device from a snapshot. Resolves with the device, whose running_device block carries
-     * the instance API URL and video (Janus) connection details.
+     * Boot a device from a snapshot. Resolves with the device, whose `running_device` block carries
+     * the instance connection details.
      */
     public startDevice(options: StartDeviceOptions): Promise<RceDevice> {
         return this.send('post', `/devices/${options.deviceId}/start`, { body: options.start, token: options.token });
@@ -153,10 +152,9 @@ export class RceManagementClient {
     }
 
     /**
-     * Normalize a device config's id to the numeric device id the management api uses. The type
-     * says number, but device configs also arrive from untyped sources (a json launch config, a
-     * javascript caller), so a numeric string is coerced and anything else throws a clear error
-     * instead of turning into a request to `/devices/NaN` and a baffling server-side error.
+     * Normalize a device config's id to the numeric device id the management api uses. Device
+     * configs also arrive from untyped sources, so a numeric string is coerced and anything else
+     * throws a clear error instead of turning into a request to `/devices/NaN`.
      */
     private parseDeviceId(id: number | string): number {
         if (typeof id === 'number' && Number.isInteger(id)) {
@@ -182,25 +180,19 @@ export class RceManagementClient {
     }
 
     /**
-     * Single choke point for HTTP so auth and error handling stay consistent, and so tests can stub
-     * one method rather than the network. A per-call token wins over the constructor token.
+     * Sends an authenticated request and returns the parsed JSON body. A per-call token wins over
+     * the constructor token. Non-2xx responses reject.
      */
     protected send<TResponse>(method: HttpMethod, path: string, options?: SendOptions): Promise<TResponse> {
         const url = this.baseUrl + path + this.buildQueryString(options?.query);
         const needleOptions: needle.NeedleOptions = {
             json: true,
-            //needle's `timeout` alias only bounds connection establishment; a server that accepts
-            //the connection but never responds would hang the request forever. Map the timeout to
-            //both the connection and first-response-byte timers, the same way request.ts does (and
-            //like there, deliberately do NOT set `read_timeout` - see request.ts for the hazards
-            //of needle's read timer)
+            //bound both connection establishment and the first response byte, the same way
+            //request.ts does (and like there, deliberately do NOT set `read_timeout`)
             open_timeout: this.timeout,
             response_timeout: this.timeout,
-            //needle's default (Node's global pooling agent, no `Connection: close`) leaves a
-            //keep-alive socket open after the response, which keeps the Node event loop alive so a
-            //CLI process that only talked to the management api never exits - see request.ts for
-            //the full story. A fresh un-pooled socket per request costs a TLS handshake, which is
-            //fine for this low-volume api.
+            //disable keep-alive/pooling so a lingering socket doesn't hold the Node event loop
+            //open after the response (see request.ts); fine for this low-volume api
             connection: 'close',
             agent: false,
             headers: {

--- a/src/RceManagementClient.ts
+++ b/src/RceManagementClient.ts
@@ -70,7 +70,7 @@ export class RceManagementClient {
 
     /**
      * Boot a device from a snapshot. Resolves with the device, whose `running_device` block carries
-     * the instance connection details.
+     * the instance API URL and video (Janus) connection details.
      */
     public startDevice(options: StartDeviceOptions): Promise<RceDevice> {
         return this.send('post', `/devices/${options.deviceId}/start`, { body: options.start, token: options.token });
@@ -180,15 +180,18 @@ export class RceManagementClient {
     }
 
     /**
-     * Sends an authenticated request and returns the parsed JSON body. A per-call token wins over
-     * the constructor token. Non-2xx responses reject.
+     * Sends an authenticated request and returns the parsed JSON body; non-2xx responses reject.
+     * The single HTTP choke point, so auth and error handling stay consistent and tests can stub
+     * one method rather than the network. A per-call token wins over the constructor token.
      */
     protected send<TResponse>(method: HttpMethod, path: string, options?: SendOptions): Promise<TResponse> {
         const url = this.baseUrl + path + this.buildQueryString(options?.query);
         const needleOptions: needle.NeedleOptions = {
             json: true,
-            //bound both connection establishment and the first response byte, the same way
-            //request.ts does (and like there, deliberately do NOT set `read_timeout`)
+            //needle's `timeout` alias only bounds connection establishment; a server that accepts the
+            //connection but never responds would hang the request forever. Bound both the connection and
+            //first-response-byte timers, the same way request.ts does (and like there, deliberately do
+            //NOT set `read_timeout` - see request.ts for the hazards of needle's read timer)
             open_timeout: this.timeout,
             response_timeout: this.timeout,
             //disable keep-alive/pooling so a lingering socket doesn't hold the Node event loop

--- a/src/RceVideoSignalingClient.ts
+++ b/src/RceVideoSignalingClient.ts
@@ -4,16 +4,9 @@ import * as WebSocket from 'ws';
 import type { IceServer } from './RceManagementClient';
 
 /**
- * Negotiates a Roku Cloud Emulator (RCE) device's video/audio stream from its Janus gateway over
- * the Janus WebSocket signaling protocol: connect() resolves with the gateway's SDP offer, the
- * caller answers it (with its own RTCPeerConnection) via sendAnswer(), and trickles its local ICE
- * candidates via sendCandidate()/sendCandidatesComplete().
- *
- * This client owns the *signaling* session only: it has no WebRTC dependency and never creates a
- * peer connection of its own. It must run somewhere with Node's `ws`, because the RCE Janus host
- * requires an `Authorization` header on the WebSocket handshake itself (which a browser WebSocket
- * cannot set); the offer/answer/candidates are plain data that can be handed off to wherever the
- * actual peer connection lives.
+ * Negotiates a Roku Cloud Emulator (RCE) device's video/audio stream over the Janus WebSocket
+ * signaling protocol. Signaling only — no WebRTC dependency: connect() resolves with the SDP offer,
+ * and the caller answers and trickles ICE via sendAnswer()/sendCandidate()/sendCandidatesComplete().
  */
 export class RceVideoSignalingClient extends EventEmitter {
     constructor(
@@ -40,9 +33,8 @@ export class RceVideoSignalingClient extends EventEmitter {
     private readonly pendingRequests = new Map<string, PendingJanusRequest>();
 
     /**
-     * Rejects the websocket-handshake promise inside a negotiate() still waiting on 'open'. Stored
-     * here because stop() strips the socket listeners that promise is built on, so stop() (and the
-     * unexpected-close handler) must be able to settle it directly.
+     * Settles the pending websocket-handshake promise; stored so stop() and the unexpected-close
+     * handler can reject it directly.
      */
     private rejectConnected: ((error: Error) => void) | undefined;
 
@@ -57,12 +49,8 @@ export class RceVideoSignalingClient extends EventEmitter {
     }
 
     /**
-     * Connect and negotiate as far as the SDP offer. Resolves with the offer and the configured ice
-     * servers. Rejects (and tears the session down) if negotiation has not completed within
-     * `negotiationTimeoutMs`.
-     *
-     * One session at a time: a second connect() while one is active rejects. Call stop() first;
-     * after stop() (or an unexpected close), connect() may be called again.
+     * Connect and negotiate as far as the SDP offer. Rejects (tearing the session down) if
+     * negotiation exceeds `negotiationTimeoutMs`. One session at a time: call stop() before reconnecting.
      */
     public async connect(): Promise<RceVideoSignalingOffer> {
         if (this.webSocket) {
@@ -303,10 +291,8 @@ export class RceVideoSignalingClient extends EventEmitter {
     }
 
     /**
-     * Resolves or rejects the pending request matching `transaction`, if there is one. A 'success' or
-     * 'event' message that carries a plugin-level error (wrong pin, unknown stream id, and so on) is
-     * still a Janus-protocol success, but is treated as a rejection here so the real reason surfaces
-     * instead of, for example, connect() later failing with a generic "no SDP offer" message.
+     * Resolves or rejects the pending request matching `transaction`, if there is one. Plugin-level
+     * errors arrive as Janus-protocol successes but are treated as rejections so the real reason surfaces.
      * @returns whether a pending request was found (and settled)
      */
     private settlePendingRequest(transaction: string | undefined, message: JanusIncomingMessage | undefined, errorMessage: string | undefined): boolean {

--- a/src/RceVideoSignalingClient.ts
+++ b/src/RceVideoSignalingClient.ts
@@ -4,34 +4,16 @@ import * as WebSocket from 'ws';
 import type { IceServer } from './RceManagementClient';
 
 /**
- * Negotiates a Roku Cloud Emulator (RCE) device's video/audio stream from its Janus gateway, using
- * the standard Janus WebSocket JSON gateway protocol (subprotocol 'janus-protocol'):
+ * Negotiates a Roku Cloud Emulator (RCE) device's video/audio stream from its Janus gateway over
+ * the Janus WebSocket signaling protocol: connect() resolves with the gateway's SDP offer, the
+ * caller answers it (with its own RTCPeerConnection) via sendAnswer(), and trickles its local ICE
+ * candidates via sendCandidate()/sendCandidatesComplete().
  *
- *   1. connect, then `{janus:'create'}` for a session
- *   2. `{janus:'attach', plugin:'janus.plugin.streaming'}` for a plugin handle
- *   3. `{janus:'message', body:{request:'watch', id, pin}}`, which resolves with an `event`
- *      carrying a jsep SDP offer
- *   4. the caller answers the offer (with its own RTCPeerConnection) and calls sendAnswer(), which
- *      sends `{janus:'message', body:{request:'start'}, jsep: answer}`
- *   5. the caller trickles its local ICE candidates via sendCandidate()/sendCandidatesComplete(),
- *      and a keepalive is sent every 25s (Janus sessions time out at 60s)
- *
- * This client owns the Janus *signaling* session only: it has no WebRTC dependency and never
- * creates a peer connection of its own. Offers, answers and ICE candidates are plain data in and
- * out; the caller is responsible for its own RTCPeerConnection and for feeding this class the
- * answer/candidates it produces.
- *
- * The reason this lives here rather than in the caller: the Janus WebSocket host used by RCE
- * instances requires an `Authorization: Bearer <management api token>` header on the WebSocket
- * handshake itself, which only a Node WebSocket client can set (a browser WebSocket cannot set
- * handshake headers), so this class is meant to run somewhere with Node's `ws`, handing the
- * resulting offer/answer/candidates off to wherever the actual peer connection lives (for example
- * across a message channel to a browser or webview).
- *
- * Janus acknowledges an asynchronous plugin request immediately with `{janus:'ack'}`, then delivers
- * the actual result later as `{janus:'event', ...}` (or `{janus:'success', ...}` for core-level
- * requests like create/attach/destroy). Both are treated as the resolution of the request that
- * shares their `transaction` id; the intervening `ack` is otherwise ignored.
+ * This client owns the *signaling* session only: it has no WebRTC dependency and never creates a
+ * peer connection of its own. It must run somewhere with Node's `ws`, because the RCE Janus host
+ * requires an `Authorization` header on the WebSocket handshake itself (which a browser WebSocket
+ * cannot set); the offer/answer/candidates are plain data that can be handed off to wherever the
+ * actual peer connection lives.
  */
 export class RceVideoSignalingClient extends EventEmitter {
     constructor(
@@ -60,8 +42,7 @@ export class RceVideoSignalingClient extends EventEmitter {
     /**
      * Rejects the websocket-handshake promise inside a negotiate() still waiting on 'open'. Stored
      * here because stop() strips the socket listeners that promise is built on, so stop() (and the
-     * unexpected-close handler) must be able to settle it directly or a connect() cancelled
-     * mid-handshake would sit unresolved until the negotiation timeout fired.
+     * unexpected-close handler) must be able to settle it directly.
      */
     private rejectConnected: ((error: Error) => void) | undefined;
 
@@ -76,15 +57,12 @@ export class RceVideoSignalingClient extends EventEmitter {
     }
 
     /**
-     * Connect and negotiate as far as the SDP offer. Resolves with the offer (and the configured
-     * ice servers, echoed back for the caller's convenience) once Janus's 'watch' request returns
-     * one. Rejects (and tears the session down via stop()) if negotiation has not reached that point
-     * within `negotiationTimeoutMs`, so a silently unresponsive gateway (a WAF sinkhole, a dropped
-     * session) fails loudly instead of leaving the caller waiting forever.
+     * Connect and negotiate as far as the SDP offer. Resolves with the offer and the configured ice
+     * servers. Rejects (and tears the session down) if negotiation has not completed within
+     * `negotiationTimeoutMs`.
      *
-     * One session at a time: a second connect() while one is active rejects (it would orphan the
-     * first websocket with its listeners still driving this client). Call stop() first; after
-     * stop() (or an unexpected close), connect() may be called again.
+     * One session at a time: a second connect() while one is active rejects. Call stop() first;
+     * after stop() (or an unexpected close), connect() may be called again.
      */
     public async connect(): Promise<RceVideoSignalingOffer> {
         if (this.webSocket) {
@@ -425,24 +403,20 @@ export class RceVideoSignalingClient extends EventEmitter {
 
 /**
  * Everything needed to negotiate a stream from a running RCE device's Janus gateway (built from the
- * device's `running_device` Janus fields, plus the management api token used for the WebSocket
- * handshake).
+ * device's `running_device` Janus fields).
  */
 export interface RceVideoSignalingConfig {
     websocketUrl: string;
     streamId: number;
     pin?: string;
     /**
-     * The management api's `janus_token` device field. This gateway uses Janus API-secret auth, so
-     * it is sent as the `apisecret` field on every Janus request (not `token`, a stored-token auth
-     * field Janus also supports but this gateway rejects with a 403 "Unauthorized request" on
-     * create). Distinct from `apiToken`, which authenticates the WebSocket handshake itself.
+     * The management api's `janus_token` device field, sent with every Janus request. Distinct from
+     * `apiToken`, which authenticates the WebSocket handshake itself.
      */
     janusToken?: string;
     /**
      * RCE management api bearer token, sent as `Authorization: Bearer <apiToken>` on the WebSocket
-     * handshake. The Janus WebSocket host requires this; it is not the same credential as
-     * `janusToken`.
+     * handshake. Not the same credential as `janusToken`.
      */
     apiToken: string;
     iceServers?: IceServer[];

--- a/src/RceVideoSignalingClient.ts
+++ b/src/RceVideoSignalingClient.ts
@@ -5,8 +5,17 @@ import type { IceServer } from './RceManagementClient';
 
 /**
  * Negotiates a Roku Cloud Emulator (RCE) device's video/audio stream over the Janus WebSocket
- * signaling protocol. Signaling only — no WebRTC dependency: connect() resolves with the SDP offer,
- * and the caller answers and trickles ICE via sendAnswer()/sendCandidate()/sendCandidatesComplete().
+ * signaling protocol: create a session, attach the streaming plugin, then a 'watch' request
+ * resolves with a jsep SDP offer. Signaling only — no WebRTC dependency: connect() resolves with
+ * the offer, and the caller answers and trickles ICE via sendAnswer()/sendCandidate()/
+ * sendCandidatesComplete(). A keepalive is sent every 25s (Janus sessions time out at 60s), and
+ * async plugin requests are acked immediately with their result delivered later as an event; both
+ * settle the pending request sharing their `transaction` id.
+ *
+ * This lives here (rather than in the caller) because the Janus WebSocket host requires an
+ * `Authorization: Bearer` header on the handshake itself, which a browser WebSocket cannot set —
+ * so this class runs under Node's `ws` and hands the offer/answer/candidates off to wherever the
+ * actual RTCPeerConnection lives (for example across a message channel to a browser or webview).
  */
 export class RceVideoSignalingClient extends EventEmitter {
     constructor(
@@ -33,8 +42,9 @@ export class RceVideoSignalingClient extends EventEmitter {
     private readonly pendingRequests = new Map<string, PendingJanusRequest>();
 
     /**
-     * Settles the pending websocket-handshake promise; stored so stop() and the unexpected-close
-     * handler can reject it directly.
+     * Settles the pending websocket-handshake promise; stored because stop() strips the socket
+     * listeners that promise is built on, so stop() and the unexpected-close handler must reject it
+     * directly or a connect() cancelled mid-handshake would hang until the negotiation timeout.
      */
     private rejectConnected: ((error: Error) => void) | undefined;
 
@@ -50,7 +60,9 @@ export class RceVideoSignalingClient extends EventEmitter {
 
     /**
      * Connect and negotiate as far as the SDP offer. Rejects (tearing the session down) if
-     * negotiation exceeds `negotiationTimeoutMs`. One session at a time: call stop() before reconnecting.
+     * negotiation exceeds `negotiationTimeoutMs`, so a silently unresponsive gateway fails loudly.
+     * One session at a time — a second connect() while one is active rejects (it would orphan the
+     * first websocket with its listeners still driving this client); call stop() before reconnecting.
      */
     public async connect(): Promise<RceVideoSignalingOffer> {
         if (this.webSocket) {
@@ -396,8 +408,9 @@ export interface RceVideoSignalingConfig {
     streamId: number;
     pin?: string;
     /**
-     * The management api's `janus_token` device field, sent with every Janus request. Distinct from
-     * `apiToken`, which authenticates the WebSocket handshake itself.
+     * The management api's `janus_token` device field, sent as the `apisecret` field on every Janus
+     * request (NOT `token`, a stored-token auth field Janus also supports but this gateway rejects
+     * with a 403 on create). Distinct from `apiToken`, which authenticates the WebSocket handshake itself.
      */
     janusToken?: string;
     /**

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -86,8 +86,9 @@ export class RokuDeploy {
     private readonly options: RokuDeployConstructorOptions;
 
     /**
-     * Resolved RCE instance urls, cached per device config for the lifetime of this instance.
-     * Failed resolutions are evicted so the next call retries.
+     * Resolved RCE instance urls, cached per device config for the lifetime of this instance so a
+     * multi-request flow avoids re-resolving through the management api on every request. Failed
+     * resolutions are evicted so the next call retries.
      */
     private readonly rceInstanceUrlsByCacheKey = new Map<string, Promise<string>>();
 
@@ -884,13 +885,17 @@ export class RokuDeploy {
     }
 
     /**
-     * Send a raw External Control Protocol (ECP) request to a device and return the response with
-     * its XML body parsed to JSON. Works for both local and Cloud Emulator devices, and can reach
-     * any ECP route even when no dedicated wrapper exists for it yet.
+     * Send a raw External Control Protocol (ECP) request to a device and return the raw response
+     * (status code and body). This is the single ECP transport: every ECP convenience method
+     * funnels through it, and it is public so any ECP route can be reached even when no dedicated
+     * wrapper exists for it yet. Local devices are addressed as `http://<host>:<ecpPort>/<route>`;
+     * Cloud Emulator devices go through their instance's `/ecp1/<route>` proxy, so callers never
+     * branch on device kind.
      * @param device the device to send the request to
      * @param route the ECP route without a leading slash (for example `query/device-info`, `keypress/Home`)
      * @param options `method` defaults to 'GET' (queries); commands like keypress and launch are POSTs.
-     *                `verify` defaults to false so raw ECP status bodies come back to the caller instead of throwing.
+     *                `verify` defaults to false so raw ECP status bodies (a 202 `FAILED` registry or
+     *                chanperf response, for example) come back to the caller instead of throwing.
      */
     public async sendEcpRequest(device: DeviceOption, route: string, options?: EcpOptions): Promise<EcpResult> {
         options = { ...this.options, ...options } as EcpOptions;
@@ -994,8 +999,8 @@ export class RokuDeploy {
     }
 
     /**
-     * Press a sequence of remote keys, in order, waiting `keyDelayMs` between presses so on-screen
-     * navigation keeps up. The first failed press throws with the failing key and step.
+     * Press a sequence of remote keys, in order, waiting for each press's response plus `keyDelayMs`
+     * so on-screen navigation keeps up. The first failed press throws with the failing key and step.
      */
     public async sendKeySequence(options: SendKeySequenceOptions): Promise<void> {
         options = { ...this.options, ...options } as SendKeySequenceOptions;
@@ -1021,7 +1026,8 @@ export class RokuDeploy {
     /**
      * Enter the developer-settings key combo on a Roku Cloud Emulator device, causing it to show
      * the on-screen developer setup wizard for the user to complete (this call only triggers that
-     * screen, it does not finish the setup). Local devices are not supported.
+     * screen, it does not finish the setup). Local devices are not supported — the combo endpoint
+     * only exists on the RCE instance api.
      */
     public async sendDeveloperSettingsCombo(options: SendDeveloperSettingsComboOptions): Promise<void> {
         options = { ...this.options, ...options } as SendDeveloperSettingsComboOptions;
@@ -2112,8 +2118,8 @@ export class RokuDeploy {
 
     /**
      * Unwrap a standard ECP response envelope: return the root element of the parsed body. Throws
-     * FailedDeviceResponseError on a non-OK `<status>` and UnparsableDeviceResponseError when the
-     * root element is missing.
+     * FailedDeviceResponseError on a non-OK `<status>` (which ECP reports with a 202 rather than an
+     * error status code) and UnparsableDeviceResponseError when the root element is missing.
      */
     private async getEcpEnvelope(result: EcpResult, rootKey: string, failureMessage: string): Promise<Record<string, any>> {
         const root = (await this.parseEcpXml(result))?.[rootKey];
@@ -2603,7 +2609,8 @@ export interface ValidateDeveloperPasswordOptions {
 }
 
 /**
- * The remote-control keys a Roku understands. Not an enforced list — key options also accept raw strings.
+ * The remote-control keys a Roku understands, in the canonical casing the device expects. Not an
+ * enforced list — key options also accept raw strings (e.g. a `Lit_<char>` literal).
  */
 export enum RemoteKey {
     Back = 'Back',

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -892,18 +892,12 @@ export class RokuDeploy {
 
     /**
      * Send a raw External Control Protocol (ECP) request to a device and return the response with
-     * its XML body parsed to JSON. This is the single ECP transport: every ECP convenience method
-     * funnels through it, and it is public so any ECP route can be reached even when no dedicated
-     * wrapper exists for it yet.
-     *
-     * Local devices are addressed as `http://<host>:<ecpPort>/<route>`; Cloud Emulator devices go
-     * through their instance's `/ecp1/<route>` proxy (authenticated with the config's api token),
-     * so callers never branch on device kind.
+     * its XML body parsed to JSON. Works for both local and Cloud Emulator devices, and can reach
+     * any ECP route even when no dedicated wrapper exists for it yet.
      * @param device the device to send the request to
      * @param route the ECP route without a leading slash (for example `query/device-info`, `keypress/Home`)
      * @param options `method` defaults to 'GET' (queries); commands like keypress and launch are POSTs.
-     *                `verify` defaults to false so raw ECP status bodies (a 202 `FAILED` registry or
-     *                chanperf response, for example) come back to the caller instead of throwing.
+     *                `verify` defaults to false so raw ECP status bodies come back to the caller instead of throwing.
      */
     public async sendEcpRequest(device: DeviceOption, route: string, options?: EcpOptions): Promise<EcpResult> {
         options = { ...this.options, ...options } as EcpOptions;
@@ -986,11 +980,8 @@ export class RokuDeploy {
     }
 
     /**
-     * Press a sequence of remote keys, in order. Each press rides the same transport as `keyPress`
-     * (LAN ECP for local devices; the RCE instance-api key route with the raw ecp1-proxy fallback
-     * for Cloud Emulator devices), waits for the previous press's response plus a small delay
-     * (keyDelayMs) so on-screen navigation keeps up, and the first failed press throws with the
-     * failing key and step.
+     * Press a sequence of remote keys, in order, waiting `keyDelayMs` between presses so on-screen
+     * navigation keeps up. The first failed press throws with the failing key and step.
      */
     public async sendKeySequence(options: SendKeySequenceOptions): Promise<void> {
         options = { ...this.options, ...options } as SendKeySequenceOptions;
@@ -1014,11 +1005,9 @@ export class RokuDeploy {
     }
 
     /**
-     * Enter the developer-settings key combo on a Roku Cloud Emulator device through its instance
-     * api (the same combo a physical remote's key sequence would send). The device then shows the
-     * on-screen developer setup wizard for the user to complete; this call only triggers that
-     * screen, it does not finish the setup itself. Local devices are not supported - the combo
-     * endpoint only exists on the RCE instance api.
+     * Enter the developer-settings key combo on a Roku Cloud Emulator device, causing it to show
+     * the on-screen developer setup wizard for the user to complete (this call only triggers that
+     * screen, it does not finish the setup). Local devices are not supported.
      */
     public async sendDeveloperSettingsCombo(options: SendDeveloperSettingsComboOptions): Promise<void> {
         options = { ...this.options, ...options } as SendDeveloperSettingsComboOptions;
@@ -1470,11 +1459,10 @@ export class RokuDeploy {
     }
 
     /**
-     * Enhance a raw device-info object into its normalized form. This camel-cases the property names and
-     * normalizes each value to its native format (boolean strings to booleans, number strings to numbers,
-     * decoding HtmlEntities, etc.). This is the same enhancement `getDeviceInfo` applies when called with
-     * `{ enhance: true }`, exposed separately so callers that already have a raw device-info object can
-     * enhance it without making another request to the device.
+     * Enhance a raw device-info object into its normalized form: camel-cases the property names and
+     * normalizes each value to its native format (booleans, numbers, decoded html entities, etc.).
+     * The same enhancement `getDeviceInfo` applies with `{ enhance: true }`, for callers that
+     * already have a raw device-info object and don't want another device request.
      * @param deviceInfo the raw device-info object to enhance
      */
     public enhanceDeviceInfo(deviceInfo: DeviceInfoRaw): DeviceInfo {
@@ -2597,10 +2585,9 @@ export interface ValidateDeveloperPasswordOptions {
 }
 
 /**
- * The remote-control keys a Roku understands, in the canonical casing the device expects. Exposed
- * for convenience and discoverability: pass a `RemoteKey` value and you get the casing right without
- * thinking about it. It is NOT an enforced list - every key option also accepts a raw string, so a
- * key without a member here (or a `Lit_<char>` literal) can still be sent.
+ * The remote-control keys a Roku understands, in the canonical casing the device expects. This is
+ * NOT an enforced list - every key option also accepts a raw string, so a key without a member
+ * here (or a `Lit_<char>` literal) can still be sent.
  */
 export enum RemoteKey {
     Back = 'Back',

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -43,7 +43,6 @@ export class RokuDeploy {
     constructor(options?: RokuDeployConstructorOptions) {
         this.options = options ?? {};
 
-        // Use custom logger if provided, otherwise use global logger
         this.logger = this.options.logger ?? logger;
     }
 
@@ -87,10 +86,8 @@ export class RokuDeploy {
     private readonly options: RokuDeployConstructorOptions;
 
     /**
-     * One resolved instance url per unique RCE device config, cached for the lifetime of this
-     * `RokuDeploy` instance, so a multi-request flow (for example sideload's closeChannel ->
-     * deleteDevChannel -> plugin_install) avoids re-resolving the instance url through the
-     * management api on every request. Failed resolutions are evicted so the next call retries.
+     * Resolved RCE instance urls, cached per device config for the lifetime of this instance.
+     * Failed resolutions are evicted so the next call retries.
      */
     private readonly rceInstanceUrlsByCacheKey = new Map<string, Promise<string>>();
 
@@ -105,19 +102,14 @@ export class RokuDeploy {
         this.logger.info('Beginning to copy files to staging folder');
         const cwd = options.cwd ?? process.cwd();
 
-        // Set defaults and resolve paths
         const rootDir = path.resolve(cwd, options.rootDir ?? './');
         const files = options.files ?? [...DefaultFiles];
 
-        // Resolve output directory - use 'out' if provided, otherwise default to staging dir
         const out = options.out
             ? path.resolve(cwd, options.out)
             : path.resolve(cwd, RokuDeploy.defaults.outDir, '.roku-deploy-staging');
 
-        //clean the staging directory
         await fsExtra.remove(out);
-
-        //make sure the staging folder exists
         await fsExtra.ensureDir(out);
 
         if (!await fsExtra.pathExists(rootDir)) {
@@ -125,11 +117,9 @@ export class RokuDeploy {
         }
 
         let fileObjects = await this.getFilePaths({ files: files, rootDir: rootDir });
-        //copy all of the files
         await Promise.all(fileObjects.map(async (fileObject) => {
             let destFilePath = util.standardizePath(`${out}/${fileObject.dest}`);
 
-            //make sure the containing folder exists
             await fsExtra.ensureDir(path.dirname(destFilePath));
 
             //sometimes the copyfile action fails due to race conditions (normally to poorly constructed src;dest; objects with duplicate files in them
@@ -2057,9 +2047,8 @@ export class RokuDeploy {
     }
 
     /**
-     * Build the HttpDetails carried by ECP wrapper errors. `sendEcpRequest()` does not retain the raw
-     * HttpResponse, so this carries what it does keep - the status code and body - which is what a
-     * caller needs to see what the device actually said.
+     * Build the HttpDetails carried by ECP wrapper errors from what `sendEcpRequest()` retains:
+     * the status code and body.
      */
     private buildEcpHttpDetails(result: EcpResult): HttpDetails {
         return {
@@ -2094,10 +2083,9 @@ export class RokuDeploy {
     }
 
     /**
-     * Unwrap a standard ECP response envelope: return the root element of the parsed body, throwing
-     * a FailedDeviceResponseError (with the device's own error message) when the element carries a
-     * non-OK `<status>` - which ECP reports with a 202 rather than an error status code - and an
-     * UnparsableDeviceResponseError when the expected root element is missing entirely.
+     * Unwrap a standard ECP response envelope: return the root element of the parsed body. Throws
+     * FailedDeviceResponseError on a non-OK `<status>` and UnparsableDeviceResponseError when the
+     * root element is missing.
      */
     private getEcpEnvelope(result: EcpResult, rootKey: string, failureMessage: string): Record<string, any> {
         const root = result.json?.[rootKey];
@@ -2411,12 +2399,10 @@ export class RokuDeploy {
      * @param deviceInfo
      */
     private normalizeDeviceInfoFieldValue(value: any) {
-        // non-string values have nothing to normalize; return them unchanged
         if (typeof value !== 'string') {
             return value;
         }
         let num: number;
-        // convert 'true' and 'false' string values to boolean
         if (value === 'true') {
             return true;
         } else if (value === 'false') {
@@ -2580,14 +2566,12 @@ export interface ValidateDeveloperPasswordOptions {
     /** Defaults to `80` (the developer web-server port) */
     port?: number;
 
-    /** Milliseconds to wait for each HTTP round-trip. Defaults to `3000`. */
+    /** Defaults to `3000` (milliseconds per HTTP round-trip) */
     timeout?: number;
 }
 
 /**
- * The remote-control keys a Roku understands, in the canonical casing the device expects. This is
- * NOT an enforced list - every key option also accepts a raw string, so a key without a member
- * here (or a `Lit_<char>` literal) can still be sent.
+ * The remote-control keys a Roku understands. Not an enforced list — key options also accept raw strings.
  */
 export enum RemoteKey {
     Back = 'Back',

--- a/src/RokuDeployOptions.ts
+++ b/src/RokuDeployOptions.ts
@@ -165,9 +165,8 @@ export interface RokuDeployOptions {
     screenshotDir?: string;
 
     /**
-     * The request timeout duration in milliseconds. Defaults to 150000ms (2 minutes 30 seconds).
-     * This is mainly useful for preventing hang ups if the Roku loses power or restarts due to a firmware bug.
-     * This is applied per network request to the device and does not apply to the total time it takes to completely execute a call to roku-deploy.
+     * The timeout for each network request to the device, in milliseconds (not for the overall
+     * roku-deploy call). Defaults to 150000 (2 minutes 30 seconds).
      */
     timeout?: number;
 

--- a/src/RokuDeploySocket.ts
+++ b/src/RokuDeploySocket.ts
@@ -79,8 +79,9 @@ export class LocalSocket extends net.Socket {
  * device's `rceToken`.
  *
  * Extending `stream.Duplex` (rather than a plain `EventEmitter`) matters: consumers hand this
- * socket to `telnet-client`, whose injected-socket guard requires internals only a real Node
- * stream provides.
+ * socket to `telnet-client`, whose `_checkSocket()` injected-socket guard requires `pipe`,
+ * `_write`, `_writableState`, `_read`, and `_readableState` — internals only a real Node stream
+ * provides.
  */
 export class RceSocket extends stream.Duplex {
     constructor(options: RceSocketOptions) {
@@ -126,7 +127,8 @@ export class RceSocket extends stream.Duplex {
      * is registered as a one-time `'connect'` listener.
      *
      * Unlike `net.Socket`, this socket cannot be reconnected: calling connect() a second time (or
-     * on a destroyed socket) throws.
+     * on a destroyed socket) throws — a second websocket would orphan the first with its listeners
+     * still feeding this stream, so both misuses fail loudly instead of leaking.
      */
     public connect(connectListener?: () => void): this {
         if (this.destroyed) {
@@ -221,8 +223,8 @@ export class RceSocket extends stream.Duplex {
     }
 
     /**
-     * Sends a chunk, unchanged, as a binary websocket frame (the RCE port endpoints reject TEXT
-     * frames). A write issued before the websocket has opened is held and flushed on `'open'`,
+     * Sends a chunk, unchanged, as a binary websocket frame (the RCE port endpoints reject a TEXT
+     * frame with close code 1003). A write issued before the websocket has opened is held and flushed on `'open'`,
      * matching the buffering `net.Socket` applies to writes issued while connecting.
      */
     public _write(chunk: Buffer | string, encoding: BufferEncoding, callback: (error?: Error | null) => void): void {

--- a/src/RokuDeploySocket.ts
+++ b/src/RokuDeploySocket.ts
@@ -7,14 +7,9 @@ import { RceManagementClient } from './RceManagementClient';
 
 /**
  * Creates a transport for one of a Roku device's telnet consoles (for example the BrightScript
- * console on port 8085) that behaves like a `net.Socket` regardless of where the device lives: a
- * local network device is reached over plain tcp, while a Roku Cloud Emulator (RCE) instance
- * exposes the same console ports as authenticated WebSocket endpoints on its instance api.
- *
- * The returned object is a near-transparent replacement for `new net.Socket()`: it exposes the same
- * `connect()`/`write()`/`destroy()`/`setTimeout()` surface and the same
- * `'connect'`/`'ready'`/`'data'`/`'close'`/`'end'`/`'error'`/`'timeout'` events, so callers never
- * need to know which transport they got.
+ * console on port 8085) that behaves like a `net.Socket` regardless of where the device lives:
+ * plain tcp for a local network device, an authenticated WebSocket for a Roku Cloud Emulator (RCE)
+ * instance. Exposes the same method surface and events as `new net.Socket()`.
  */
 export function createRokuDeploySocket(options: SocketOptions): RokuDeploySocket {
     //runtime guard for javascript callers, since a registry name (string) cannot be resolved to a

--- a/src/RokuDeploySocket.ts
+++ b/src/RokuDeploySocket.ts
@@ -7,19 +7,14 @@ import { RceManagementClient } from './RceManagementClient';
 
 /**
  * Creates a transport for one of a Roku device's telnet consoles (for example the BrightScript
- * console on port 8085, the SceneGraph debug server on port 8080, or the screensaver console on
- * port 8087) that behaves like a `net.Socket` regardless of where the device lives:
+ * console on port 8085) that behaves like a `net.Socket` regardless of where the device lives: a
+ * local network device is reached over plain tcp, while a Roku Cloud Emulator (RCE) instance
+ * exposes the same console ports as authenticated WebSocket endpoints on its instance api.
  *
- *   - a local network device exposes these as plain-tcp telnet ports
- *   - a Roku Cloud Emulator (RCE) instance exposes the same ports as WebSocket endpoints on its
- *     instance api (`<instanceUrl>/api/v0/ports/<port>`), authed by an
- *     `Authorization: Bearer <rceToken>` header on the WebSocket handshake
- *
- * The returned object is meant as a near-transparent replacement for `new net.Socket()`: it exposes
- * the same `connect()`/`write()`/`destroy()`/`setTimeout()` surface and the same
- * `'connect'`/`'ready'`/`'data'`/`'close'`/`'end'`/`'error'`/`'timeout'` events, satisfying both a
- * real `net.Socket` and this factory's own RCE implementation. Callers that only care about console
- * bytes never need to know (or change any of their code based on) which transport they got.
+ * The returned object is a near-transparent replacement for `new net.Socket()`: it exposes the same
+ * `connect()`/`write()`/`destroy()`/`setTimeout()` surface and the same
+ * `'connect'`/`'ready'`/`'data'`/`'close'`/`'end'`/`'error'`/`'timeout'` events, so callers never
+ * need to know which transport they got.
  */
 export function createRokuDeploySocket(options: SocketOptions): RokuDeploySocket {
     //runtime guard for javascript callers, since a registry name (string) cannot be resolved to a
@@ -43,10 +38,9 @@ export function createRokuDeploySocket(options: SocketOptions): RokuDeploySocket
 }
 
 /**
- * A `net.Socket` wired up to connect to a local device's plain-tcp telnet console using the host and
- * port resolved by `createRokuDeploySocket()`. Every behavior other than `connect()` is real
- * `net.Socket` behavior inherited unchanged; that is the entire point of extending it directly
- * instead of wrapping it in another layer.
+ * A `net.Socket` wired up to connect to a local device's plain-tcp telnet console using the host
+ * and port given at construction. Everything other than `connect()` is inherited `net.Socket`
+ * behavior, unchanged.
  */
 export class LocalSocket extends net.Socket {
     constructor(options: LocalSocketOptions) {
@@ -60,12 +54,9 @@ export class LocalSocket extends net.Socket {
     private readonly port: number;
 
     /**
-     * Connects to the host and port resolved by the factory that created this socket, matching
-     * `net.Socket`'s own no-argument-address form: the address was already decided when this
-     * instance was constructed, so there is nothing left for a caller to specify here. The
-     * additional overloads below exist only so this override remains structurally compatible with
-     * `net.Socket`'s own `connect()` overloads; nothing in this codebase calls them on a
-     * `LocalRokuDeploySocket` directly.
+     * Connects to the host and port this socket was constructed with. The additional overloads
+     * below exist only so this override remains structurally compatible with `net.Socket`'s own
+     * `connect()` overloads.
      */
     public connect(connectListener?: () => void): this;
     public connect(connectOptions: net.SocketConnectOpts, connectListener?: () => void): this;
@@ -89,14 +80,12 @@ export class LocalSocket extends net.Socket {
 
 /**
  * A `stream.Duplex` wired up to connect to a Roku Cloud Emulator (RCE) instance's telnet console
- * over its WebSocket endpoint (`<instanceUrl>/api/v0/ports/<port>`), authed by an
- * `Authorization: Bearer <rceToken>` header on the WebSocket handshake.
+ * over its WebSocket endpoint (`<instanceUrl>/api/v0/ports/<port>`), authenticated with the
+ * device's `rceToken`.
  *
- * Extending `stream.Duplex` (rather than a plain `EventEmitter`) matters beyond just matching
- * `net.Socket`'s event surface: consumers hand this socket to `telnet-client`, whose `_checkSocket()`
- * guard (used whenever a socket is injected rather than created internally) requires `pipe`,
- * `_write`, `_writableState`, `_read`, and `_readableState`, all of which only a real Node stream
- * provides.
+ * Extending `stream.Duplex` (rather than a plain `EventEmitter`) matters: consumers hand this
+ * socket to `telnet-client`, whose injected-socket guard requires internals only a real Node
+ * stream provides.
  */
 export class RceSocket extends stream.Duplex {
     constructor(options: RceSocketOptions) {
@@ -137,15 +126,12 @@ export class RceSocket extends stream.Duplex {
     private pendingWrite: PendingWrite | undefined;
 
     /**
-     * Fire-and-forget, exactly like `net.Socket#connect()`: resolves the RCE instance url, opens the
-     * websocket, and emits `'connect'` then `'ready'` once the handshake completes (the same order
-     * `net.Socket` uses). `connectListener` is registered the same way `net.Socket` registers its
-     * own connect callback: as a one-time `'connect'` listener.
+     * Fire-and-forget, like `net.Socket#connect()`: resolves the RCE instance url, opens the
+     * websocket, and emits `'connect'` then `'ready'` once the handshake completes. `connectListener`
+     * is registered as a one-time `'connect'` listener.
      *
-     * Unlike `net.Socket` (which allows reconnecting a closed socket), calling this a second time
-     * throws: a second websocket would orphan the first one with its listeners still feeding this
-     * stream, and a destroyed Duplex cannot be revived, so both misuses fail loudly instead of
-     * leaking or silently never calling back.
+     * Unlike `net.Socket`, this socket cannot be reconnected: calling connect() a second time (or
+     * on a destroyed socket) throws.
      */
     public connect(connectListener?: () => void): this {
         if (this.destroyed) {
@@ -240,13 +226,9 @@ export class RceSocket extends stream.Duplex {
     }
 
     /**
-     * Sends a chunk as a binary websocket frame. The RCE port endpoints accept binary frames only
-     * (a TEXT frame is rejected with close code 1003), and bytes are forwarded unchanged, which is
-     * exactly the byte parity a raw tcp socket provides.
-     *
-     * A write issued before the websocket has opened is held and flushed on `'open'`, the same
-     * buffering `net.Socket` applies to writes issued while connecting, so the idiomatic
-     * `socket.connect(); socket.write(...)` pattern works on both transports.
+     * Sends a chunk, unchanged, as a binary websocket frame (the RCE port endpoints reject TEXT
+     * frames). A write issued before the websocket has opened is held and flushed on `'open'`,
+     * matching the buffering `net.Socket` applies to writes issued while connecting.
      */
     public _write(chunk: Buffer | string, encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
         const bufferedChunk = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding);
@@ -267,10 +249,9 @@ export class RceSocket extends stream.Duplex {
     }
 
     /**
-     * Implements the writable half of `end()`. `net.Socket` sends a FIN here; a websocket has no
-     * half-close, so the closest equivalent is starting the close handshake. The websocket's own
-     * `'close'` event (see `beginConnecting()`) then ends the readable side and the stream destroys
-     * itself, so `end()` still arrives at exactly one `'close'` event, just like a `net.Socket`.
+     * Implements the writable half of `end()`. A websocket has no half-close, so the closest
+     * equivalent to `net.Socket`'s FIN is starting the close handshake; the websocket's `'close'`
+     * event then ends the readable side, so `end()` still arrives at exactly one `'close'` event.
      */
     public _final(callback: (error?: Error | null) => void): void {
         if (this.webSocket?.readyState === WebSocket.OPEN) {
@@ -500,9 +481,8 @@ export interface SocketOptions {
     device: DeviceConfig;
     /**
      * the device port to connect to (for example 8085 for the BrightScript console, 8080 for the
-     * SceneGraph debug server, or 8087 for the screensaver console). A local device connects to this
-     * tcp port directly; an RCE device reaches the same port through the instance api's
-     * `/api/v0/ports/<port>` WebSocket route
+     * SceneGraph debug server, or 8087 for the screensaver console); both transports reach the same
+     * console port
      */
     port: number;
 }
@@ -523,11 +503,10 @@ export interface RceSocketOptions extends SocketOptions {
 
 /**
  * The socket-shaped surface consumers write against instead of `net.Socket` directly. A real
- * `net.Socket` (and therefore `LocalRokuDeploySocket`, which extends it) satisfies this interface
- * structurally; `RceRokuDeploySocket` implements it directly. `remoteAddress`, `remotePort`,
- * `localAddress`, `localPort`, `localFamily`, and `timeout` are informational fields carried over
- * from `net.Socket` for logging; an RCE connection has no tcp-level address to report for the first
- * five, so it always reports `undefined` for those.
+ * `net.Socket` (and therefore `LocalSocket`, which extends it) satisfies this interface
+ * structurally; `RceSocket` implements it directly. The address fields and `timeout` are
+ * informational, carried over from `net.Socket` for logging; an RCE connection has no tcp-level
+ * address, so it reports `undefined` for those.
  */
 export interface RokuDeploySocket extends NodeJS.ReadWriteStream {
     connect: (connectListener?: () => void) => this;

--- a/src/commands/RemoteControlCommand.ts
+++ b/src/commands/RemoteControlCommand.ts
@@ -72,7 +72,7 @@ export class RemoteControlCommand {
                         rokuDeployKeyName = 'Info';
                     } else {
                         if (key.ctrl && key.name === 'c') {
-                            process.exit(); // We provide a way to exit the program
+                            process.exit();
                         }
 
                         let text = key.name;

--- a/src/dateUtils.ts
+++ b/src/dateUtils.ts
@@ -1,10 +1,5 @@
 /**
  * Dependency-free date/duration formatting helpers.
- *
- * These replace the `dateformat`, `dayjs`, `moment`, and `parse-ms` packages,
- * each of which was used at a single call site for trivial formatting. This is a
- * leaf module that imports nothing else from the project, so it is safe to consume
- * from low-level files (e.g. `Logger`, `Stopwatch`) without creating import cycles.
  */
 
 /** Left-pad a number with zeros to the given width. */

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,18 +1,13 @@
 import * as crypto from 'crypto';
 
-// Module seam for `fetch` so tests can stub it. On Node 18, `fetch` is a lazy
-// getter on `globalThis` (not an own property), so `sinon.stub(globalThis, 'fetch')`
-// fails there — routing calls through this object gives a regular, stubbable export.
+//seam so tests can stub `fetch` (sinon can't stub Node 18's lazy `globalThis.fetch` getter directly)
 export const httpClient = {
     fetch: globalThis.fetch?.bind(globalThis)
 };
 
 /**
- * Issue an HTTP request with digest authentication.
- * Performs the two-step challenge/response dance: the first request
- * collects the `WWW-Authenticate` challenge, the second sends a computed
- * `Authorization` header. Response bodies are not consumed — callers get
- * the raw `Response` and inspect status/headers only.
+ * Issue an HTTP request with digest authentication. Response bodies are not
+ * consumed — callers get the raw `Response` and inspect status/headers only.
  */
 export async function fetchWithDigest(
     url: string,
@@ -21,7 +16,6 @@ export async function fetchWithDigest(
     const { username, password, timeout, ...fetchInit } = init;
     const method = fetchInit.method.toUpperCase();
 
-    // Step 1 — issue the request unauthenticated to collect the challenge.
     const step1 = await fetchWithTimeout(url, fetchInit, timeout);
     if (step1.status !== 401) {
         return step1;
@@ -31,7 +25,6 @@ export async function fetchWithDigest(
         return step1;
     }
 
-    // Step 2 — compute the digest response and retry.
     const challenge = parseDigestChallenge(wwwAuth);
     const uri = new URL(url).pathname;
     const authorization = buildDigestAuthorization({
@@ -54,7 +47,7 @@ function fetchWithTimeout(url: string, init: RequestInit, timeout: number): Prom
         .finally(() => clearTimeout(timer));
 }
 
-//parse the comma-separated key/value pairs out of a `WWW-Authenticate: Digest ...` header. Values may be bare or double-quoted.
+/** Parse a `WWW-Authenticate: Digest ...` header into key/value pairs */
 export function parseDigestChallenge(header: string): Record<string, string> {
     const out: Record<string, string> = {};
     const body = header.replace(/^Digest\s+/i, '');
@@ -70,7 +63,7 @@ function md5(input: string): string {
     return crypto.createHash('md5').update(input).digest('hex');
 }
 
-//build an RFC 2617 `Authorization: Digest ...` header from a parsed challenge.
+/** Build an `Authorization: Digest ...` header from a parsed challenge */
 export function buildDigestAuthorization(params: {
     username: string;
     password: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-//export everything from the RokuDeploy file
 export * from './RokuDeploy';
 export * from './util';
 export * from './RokuDeployOptions';

--- a/src/request.ts
+++ b/src/request.ts
@@ -27,12 +27,9 @@ export class Request {
         const { url, data, needleOptions } = this.translateOptions(params, 'POST');
         //Never let needle's own digest dance send a request body: needle sends the FULL body on the
         //unauthenticated first leg, but the Roku answers that leg's 401 without reading the body and closes
-        //the socket. A body still being written at that moment dies with a raw `write EPIPE`, and needle
-        //fails the whole request before its 401 retry can run. (Bodies small enough to fit in the socket
-        //buffers finish writing before the close, which is why only large zips ever hit this.)
-        //`request`/`postman-request` never had this problem because they never sent the body
-        //unauthenticated: the first leg was a bodyless probe, and the body only went out WITH the
-        //Authorization header. Replicate that here for any authenticated POST that has a body.
+        //the socket, so large bodies (e.g. zips) die with a raw `write EPIPE` before needle's 401 retry can
+        //run. `request`/`postman-request` only ever sent the body WITH the Authorization header (the first
+        //leg was a bodyless probe); replicate that here for any authenticated POST that has a body.
         if (data && needleOptions.auth === 'digest') {
             return this.postWithDigestPreflight(url, data, needleOptions, callback);
         }
@@ -135,31 +132,22 @@ export class Request {
         const needleOptions: needle.NeedleOptions = {
             //Roku responses are HTML/XML that roku-deploy parses by hand; never let needle auto-parse them
             parse_response: false,
-            //`request` had a single `timeout` that governed how long to wait to establish the connection and
-            //receive a response. Map it to needle's `open_timeout` (connection) and `response_timeout` (time to
-            //first response byte). Deliberately do NOT set `read_timeout`: needle's read-timer is re-armed on
-            //every chunk and, in the digest-auth retry path, a read-timer can be left running after the request
-            //has already completed — it later fires `request.destroy()` and emits a spurious error, and (worse)
-            //keeps the Node event loop alive so a process that only made roku-deploy requests never exits.
+            //map `request`'s single `timeout` to needle's `open_timeout` (connection) and `response_timeout`
+            //(time to first response byte). Deliberately do NOT set `read_timeout`: in the digest-auth retry
+            //path its re-armed read-timer can outlive the request, later firing `request.destroy()` with a
+            //spurious error and keeping the Node event loop alive so the process never exits.
             open_timeout: params.timeout,
             response_timeout: params.timeout,
             headers: params.headers
         };
 
-        //`request` was configured with `agentOptions: { keepAlive: false }` so each exchange used a fresh
-        //socket that closed when done. needle does NOT honor `agentOptions`, and on modern Node it does not
-        //send `Connection: close` by default, so the socket to the Roku is left open (keep-alive) after the
-        //response. That lingering socket keeps the Node event loop alive, so a process that only made
-        //roku-deploy requests never exits. Translate the old keepAlive:false intent into needle's
-        //`connection: 'close'` so needle sends `Connection: close` and tears the socket down after each
-        //response. Only skip this if the caller explicitly asked to keep the connection alive.
-        //
-        //ALSO pass `agent: false`. needle defaults `agent` to null, which makes Node use `http.globalAgent`
-        //- a POOLING agent. The `Connection: close` header alone does NOT stop that pooling: the request
-        //immediately following an on-device delete could be handed a POOLED keep-alive socket that the Roku
-        //had already closed, producing an instant ECONNRESET ("socket hang up"). `agent: false` tells Node to
-        //create a brand-new, un-pooled socket for every request and destroy it afterward, so a dead socket
-        //can never be handed to the next request. The `Connection: close` header stays as belt-and-suspenders.
+        //`request` used `agentOptions: { keepAlive: false }` so each exchange got a fresh socket that closed
+        //when done. needle ignores `agentOptions` and leaves the socket open, which keeps the Node event
+        //loop alive so the process never exits — so send `Connection: close` via needle's `connection`
+        //option. ALSO pass `agent: false`: needle otherwise uses the POOLING `http.globalAgent`, which can
+        //hand the next request a pooled keep-alive socket the Roku already closed (instant ECONNRESET).
+        //`agent: false` forces a fresh, un-pooled socket per request; the `Connection: close` header stays
+        //as belt-and-suspenders. Only skip this if the caller explicitly asked to keep the connection alive.
         if (params.agentOptions?.keepAlive !== true) {
             needleOptions.connection = 'close';
             needleOptions.agent = false;
@@ -273,18 +261,10 @@ export class Request {
 
     /**
      * Reshape needle's response into the `request`-compatible response roku-deploy expects (and attaches
-     * to thrown errors).
-     *
-     * Maximum-parity strategy: needle's callback `resp` is the *same* underlying Node
-     * `http.IncomingMessage` that `postman-request` exposed (needle just augments it with `.body`/`.raw`/
-     * `.bytes`). So rather than fabricate a minimal plain object — which would drop everything underneath
-     * (`statusCode`/`statusMessage`/`rawHeaders`/`httpVersion*`/`socket`/`req`/`complete`/... that a
-     * consumer might reach into) — we KEEP needle's IncomingMessage and only layer on the two things
-     * `request`/`postman-request` added on top of it:
-     *   1. a `.request` object exposing the outgoing-request fields consumers read (`host`, `href`, ...),
-     *   2. a string `.body` (postman put the decoded string here; needle leaves a Buffer under
-     *      `parse_response:false`).
-     * This way the vast majority of the old response's reachable surface is reproduced for free.
+     * to thrown errors). needle's callback `resp` is the *same* underlying Node `http.IncomingMessage`
+     * that `postman-request` exposed, so we KEEP it (preserving its full reachable surface) and only
+     * layer on the two things `request`/`postman-request` added: a `.request` object exposing the
+     * outgoing-request fields consumers read, and a string `.body`.
      */
     private buildResponse(needleResponse: any, url: string, body: string): RequestResponse {
         //`request`/`postman-request` could hand back a callback with no response object; roku-deploy's
@@ -397,10 +377,8 @@ export const request = new Request();
 
 /**
  * The subset of the legacy `request`/`postman-request` options object that roku-deploy actually
- * builds and this shim consumes. We previously typed these as `request.OptionsWithUrl` (from
- * `@types/request`), but that pulled a dependency purely for a type and forced `as any` reads for the
- * fields the `@types/request` surface didn't cleanly expose. Declaring exactly what we use lets us drop
- * `@types/request` entirely and read every field type-safely.
+ * builds and this shim consumes. Declared explicitly (rather than depending on `@types/request`
+ * purely for a type) so every field reads type-safely.
  */
 export interface RequestOptions {
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -26,13 +26,10 @@ export class Request {
     public post(params: RequestOptions, callback: RequestCallback) {
         const { url, data, needleOptions } = this.translateOptions(params, 'POST');
         //Never let needle's own digest dance send a request body: needle sends the FULL body on the
-        //unauthenticated first leg, but the Roku answers that leg's 401 without reading the body and closes
-        //the socket. A body still being written at that moment dies with a raw `write EPIPE`, and needle
-        //fails the whole request before its 401 retry can run. (Bodies small enough to fit in the socket
-        //buffers finish writing before the close, which is why only large zips ever hit this.)
-        //`request`/`postman-request` never had this problem because they never sent the body
-        //unauthenticated: the first leg was a bodyless probe, and the body only went out WITH the
-        //Authorization header. Replicate that here for any authenticated POST that has a body.
+        //unauthenticated first leg, but the Roku answers the 401 without reading it and closes the socket —
+        //a body still mid-write dies with `write EPIPE` before needle's retry can run (only large zips hit
+        //this; smaller bodies fit in the socket buffers). `request` only ever sent the body WITH the
+        //Authorization header; replicate that for any authenticated POST that has a body.
         if (data && needleOptions.auth === 'digest') {
             return this.postWithDigestPreflight(url, data, needleOptions, callback);
         }
@@ -114,11 +111,10 @@ export class Request {
         //getToFile) listens on `'error'`, so bridge `'err'` -> `'error'` to preserve that behavior.
         stream.on('err', (err) => stream.emit('error', err));
 
-        //digest auth in streaming mode: needle issues the unauthenticated request, emits a `'response'`
-        //for the 401 challenge, and *then* transparently retries with the Authorization header (emitting
-        //a second `'response'`). `request`/`postman-request` only ever surfaced the final response, and
-        //roku-deploy's `getToFile` treats any non-200 `'response'` as a hard failure. So when we're doing
-        //digest auth, swallow the intermediate 401 `'response'` event and only forward the retried one.
+        //digest auth in streaming mode: needle emits a `'response'` for the 401 challenge and a second one
+        //for the authenticated retry. `request` only ever surfaced the final response, and roku-deploy's
+        //`getToFile` treats any non-200 `'response'` as a hard failure — so swallow the intermediate 401
+        //and forward only the retried response.
         if (needleOptions.auth && needleOptions.username !== undefined) {
             this.interceptIntermediate401(stream);
         }
@@ -135,36 +131,30 @@ export class Request {
         const needleOptions: needle.NeedleOptions = {
             //Roku responses are HTML/XML that roku-deploy parses by hand; never let needle auto-parse them
             parse_response: false,
-            //never let needle charset-decode a response: a signed pkg download served with a charset in its
-            //content-type (the RCE instance proxy does this) would have every non-utf8 byte replaced with
-            //U+FFFD, corrupting the binary. `request` never transcoded either (plain utf8 only), so this is
-            //also parity; `coerceBody` handles the Buffer->string conversion for text paths.
+            //never let needle charset-decode a response: a signed pkg served with a charset in its
+            //content-type (the RCE instance proxy does this) would get every non-utf8 byte replaced with
+            //U+FFFD, corrupting the binary. `request` never transcoded either; `coerceBody` handles the
+            //Buffer->string conversion for text paths.
             decode_response: false,
-            //`request` had a single `timeout` that governed how long to wait to establish the connection and
-            //receive a response. Map it to needle's `open_timeout` (connection) and `response_timeout` (time to
-            //first response byte). Deliberately do NOT set `read_timeout`: needle's read-timer is re-armed on
-            //every chunk and, in the digest-auth retry path, a read-timer can be left running after the request
-            //has already completed — it later fires `request.destroy()` and emits a spurious error, and (worse)
-            //keeps the Node event loop alive so a process that only made roku-deploy requests never exits.
+            //map `request`'s single `timeout` onto needle's `open_timeout` (connection) and `response_timeout`
+            //(time to first byte). Deliberately do NOT set `read_timeout`: its per-chunk re-armed timer can be
+            //left running after a digest-auth retry completes — later firing a spurious `request.destroy()`
+            //error and keeping the Node event loop alive so the process never exits.
             open_timeout: params.timeout,
             response_timeout: params.timeout,
             headers: params.headers
         };
 
-        //`request` was configured with `agentOptions: { keepAlive: false }` so each exchange used a fresh
-        //socket that closed when done. needle does NOT honor `agentOptions`, and on modern Node it does not
-        //send `Connection: close` by default, so the socket to the Roku is left open (keep-alive) after the
-        //response. That lingering socket keeps the Node event loop alive, so a process that only made
-        //roku-deploy requests never exits. Translate the old keepAlive:false intent into needle's
-        //`connection: 'close'` so needle sends `Connection: close` and tears the socket down after each
-        //response. Only skip this if the caller explicitly asked to keep the connection alive.
+        //`request` used `agentOptions: { keepAlive: false }`: a fresh socket per exchange, closed when done.
+        //needle ignores `agentOptions` and does not send `Connection: close` on modern Node, so the socket
+        //to the Roku stays open after the response and keeps the Node event loop alive — a process that only
+        //made roku-deploy requests never exits. `connection: 'close'` restores the old intent (skipped only
+        //when the caller explicitly asked for keep-alive).
         //
-        //ALSO pass `agent: false`. needle defaults `agent` to null, which makes Node use `http.globalAgent`
-        //- a POOLING agent. The `Connection: close` header alone does NOT stop that pooling: the request
-        //immediately following an on-device delete could be handed a POOLED keep-alive socket that the Roku
-        //had already closed, producing an instant ECONNRESET ("socket hang up"). `agent: false` tells Node to
-        //create a brand-new, un-pooled socket for every request and destroy it afterward, so a dead socket
-        //can never be handed to the next request. The `Connection: close` header stays as belt-and-suspenders.
+        //ALSO pass `agent: false`: needle otherwise uses Node's POOLING `http.globalAgent`, and the header
+        //alone does not stop pooling — the request right after an on-device delete could be handed a pooled
+        //keep-alive socket the Roku had already closed, an instant ECONNRESET ("socket hang up").
+        //`agent: false` forces a fresh un-pooled socket per request, destroyed afterward.
         if (params.agentOptions?.keepAlive !== true) {
             needleOptions.connection = 'close';
             needleOptions.agent = false;

--- a/src/request.ts
+++ b/src/request.ts
@@ -5,17 +5,10 @@ import type { ReadStream } from 'fs';
 import { buildDigestAuthorization, parseDigestChallenge } from './fetch';
 
 /**
- * A thin compatibility shim over `needle` that mimics the small slice of the
- * `request`/`postman-request` API that roku-deploy relies on. We migrated off
- * `postman-request` (unmaintained, pulls in a large dependency tree) but a lot
- * of roku-deploy's public surface — most notably the `results`/`response`
- * object attached to thrown errors — was shaped by `request`. To keep this a
- * non-breaking change, this shim reconstructs that same shape on top of
- * needle's response object.
- *
- * Only `post` and `get` are implemented, since those are the only verbs
- * roku-deploy uses. `get` additionally supports the callback-less streaming
- * form (`request.get(opts).on(...).pipe(...)`) used when downloading files.
+ * A thin compatibility shim over `needle` that mimics the slice of the `request`/`postman-request`
+ * API that roku-deploy relies on — including the `results`/`response` shape attached to thrown
+ * errors — so migrating off `postman-request` was non-breaking. Only `post` and `get` are
+ * implemented; `get` also supports the callback-less streaming form used for file downloads.
  */
 export class Request {
 
@@ -25,11 +18,8 @@ export class Request {
      */
     public post(params: RequestOptions, callback: RequestCallback) {
         const { url, data, needleOptions } = this.translateOptions(params, 'POST');
-        //Never let needle's own digest dance send a request body: needle sends the FULL body on the
-        //unauthenticated first leg, but the Roku answers that leg's 401 without reading the body and closes
-        //the socket, so large bodies (e.g. zips) die with a raw `write EPIPE` before needle's 401 retry can
-        //run. `request`/`postman-request` only ever sent the body WITH the Authorization header (the first
-        //leg was a bodyless probe); replicate that here for any authenticated POST that has a body.
+        //needle's own digest flow sends the full body on the unauthenticated first leg, which the Roku
+        //rejects mid-upload (`write EPIPE` on large zips) — so do the challenge dance ourselves, bodyless first
         if (data && needleOptions.auth === 'digest') {
             return this.postWithDigestPreflight(url, data, needleOptions, callback);
         }
@@ -37,11 +27,9 @@ export class Request {
     }
 
     /**
-     * POST a request whose body is only ever sent WITH an Authorization header: a bodyless probe collects
-     * the device's digest challenge, we compute the `Authorization` header ourselves, and the real request
-     * goes out pre-authorized (needle sees the header and skips its own 401 dance). If the probe doesn't
-     * yield a usable challenge (endpoint not auth-protected, unexpected status), the real request is sent
-     * unchanged and needle's own 401 dance remains as the fallback.
+     * POST where the body is only ever sent WITH an Authorization header: a bodyless probe collects
+     * the digest challenge, then the real request goes out pre-authorized. Falls back to needle's
+     * own 401 dance if the probe yields no usable challenge.
      */
     private postWithDigestPreflight(url: string, data: any, needleOptions: needle.NeedleOptions, callback: RequestCallback) {
         //probe with no body and NO credentials: we want the raw 401 challenge back, not needle answering it
@@ -111,11 +99,8 @@ export class Request {
         //getToFile) listens on `'error'`, so bridge `'err'` -> `'error'` to preserve that behavior.
         stream.on('err', (err) => stream.emit('error', err));
 
-        //digest auth in streaming mode: needle issues the unauthenticated request, emits a `'response'`
-        //for the 401 challenge, and *then* transparently retries with the Authorization header (emitting
-        //a second `'response'`). `request`/`postman-request` only ever surfaced the final response, and
-        //roku-deploy's `getToFile` treats any non-200 `'response'` as a hard failure. So when we're doing
-        //digest auth, swallow the intermediate 401 `'response'` event and only forward the retried one.
+        //needle's streaming digest auth emits a `'response'` for the intermediate 401 challenge before
+        //retrying; `request` only surfaced the final response, so swallow the 401 and forward the retry
         if (needleOptions.auth && needleOptions.username !== undefined) {
             this.interceptIntermediate401(stream);
         }
@@ -132,22 +117,15 @@ export class Request {
         const needleOptions: needle.NeedleOptions = {
             //Roku responses are HTML/XML that roku-deploy parses by hand; never let needle auto-parse them
             parse_response: false,
-            //map `request`'s single `timeout` to needle's `open_timeout` (connection) and `response_timeout`
-            //(time to first response byte). Deliberately do NOT set `read_timeout`: in the digest-auth retry
-            //path its re-armed read-timer can outlive the request, later firing `request.destroy()` with a
-            //spurious error and keeping the Node event loop alive so the process never exits.
+            //map `request`'s single `timeout` onto needle's connection and first-byte timeouts. Don't set
+            //`read_timeout`: its re-armed timer can outlive a digest-auth retry and hang the process.
             open_timeout: params.timeout,
             response_timeout: params.timeout,
             headers: params.headers
         };
 
-        //`request` used `agentOptions: { keepAlive: false }` so each exchange got a fresh socket that closed
-        //when done. needle ignores `agentOptions` and leaves the socket open, which keeps the Node event
-        //loop alive so the process never exits — so send `Connection: close` via needle's `connection`
-        //option. ALSO pass `agent: false`: needle otherwise uses the POOLING `http.globalAgent`, which can
-        //hand the next request a pooled keep-alive socket the Roku already closed (instant ECONNRESET).
-        //`agent: false` forces a fresh, un-pooled socket per request; the `Connection: close` header stays
-        //as belt-and-suspenders. Only skip this if the caller explicitly asked to keep the connection alive.
+        //unlike `request`, needle pools keep-alive sockets, which keeps the process alive after we're done
+        //and can reuse a socket the Roku already closed (ECONNRESET) — force a fresh socket that closes
         if (params.agentOptions?.keepAlive !== true) {
             needleOptions.connection = 'close';
             needleOptions.agent = false;
@@ -200,16 +178,9 @@ export class Request {
     }
 
     /**
-     * Convert a `request`-style `formData` object into the shape needle's multipart
-     * builder understands.
-     *
-     * - `request` silently dropped `null`/`undefined`/empty-string fields. needle's
-     *   multipart builder instead throws `"value missing for multipart!"` on empty
-     *   values, so we drop those fields entirely (preserving the old behavior).
-     * - `request` accepted a readable stream (e.g. the zip `fs.ReadStream`) as a
-     *   field value. needle's multipart builder does not handle streams, so we
-     *   translate a stream into needle's documented `{ file, content_type }` form
-     *   using the stream's `path`.
+     * Convert a `request`-style `formData` object into needle's multipart shape: drop empty
+     * fields (needle throws where `request` silently dropped them) and translate readable
+     * streams into needle's `{ file, content_type }` file-by-path form.
      */
     private translateFormData(formData: Record<string, any> | undefined): Record<string, any> {
         const result: Record<string, any> = {};
@@ -241,12 +212,8 @@ export class Request {
     }
 
     /**
-     * Coerce needle's response body into the `string` that roku-deploy expects.
-     * With `parse_response: false`, needle hands back a `Buffer` (an *empty* Buffer
-     * for empty responses such as a bare 401), whereas `request`/`postman-request`
-     * always delivered a decoded string. roku-deploy's `checkRequest` guards on
-     * `typeof body === 'string'`, so anything other than a string would be
-     * misreported as an unparsable response.
+     * Coerce needle's response body into the `string` roku-deploy expects: with `parse_response: false`
+     * needle hands back a `Buffer`, and roku-deploy's `checkRequest` guards on `typeof body === 'string'`.
      */
     private coerceBody(body: any): string {
         if (Buffer.isBuffer(body)) {
@@ -261,10 +228,7 @@ export class Request {
 
     /**
      * Reshape needle's response into the `request`-compatible response roku-deploy expects (and attaches
-     * to thrown errors). needle's callback `resp` is the *same* underlying Node `http.IncomingMessage`
-     * that `postman-request` exposed, so we KEEP it (preserving its full reachable surface) and only
-     * layer on the two things `request`/`postman-request` added: a `.request` object exposing the
-     * outgoing-request fields consumers read, and a string `.body`.
+     * to thrown errors): keep needle's `http.IncomingMessage` and layer on `.request` and a string `.body`.
      */
     private buildResponse(needleResponse: any, url: string, body: string): RequestResponse {
         //`request`/`postman-request` could hand back a callback with no response object; roku-deploy's
@@ -274,12 +238,8 @@ export class Request {
             return undefined;
         }
 
-        //Parse with the legacy `url.parse()` to match postman-request's `response.request.uri` exactly: it
-        //was a Node `Url` object (host WITH port, plus auth/hash/query/search/slashes/protocol/port). The
-        //WHATWG `URL` would strip the default `:80` and omit these fields, so we deliberately use the legacy
-        //parser here for byte-parity with what consumers read off `response.request.uri.*`.
-        //`url.parse()` is total for string input (it never throws — a bare token like 'not-a-valid-url'
-        //yields null host/hostname and the token as path/pathname), so no try/catch is needed.
+        //use legacy `url.parse()` (which never throws) for byte-parity with postman-request's
+        //`response.request.uri` Node `Url` object — WHATWG `URL` strips the default `:80` and omits fields
         const u = urlModule.parse(url);
         const uri: Record<string, any> = {
             protocol: u.protocol,
@@ -303,10 +263,8 @@ export class Request {
         //here under parse_response:false, so overwrite with the decoded string to match.
         response.body = body;
 
-        //`request`/`postman-request` exposed its outgoing `Request` object at `response.request`. Its
-        //library-internal guts (`_auth`, `_form`, `_qs`, `httpModule`, `pool`, ...) can't exist without the
-        //`request` package, but we reproduce every CONSUMABLE field a caller could portably read. Don't
-        //clobber it if needle/Node ever populates one.
+        //reproduce every consumable field of `request`'s `response.request` object. Don't clobber it
+        //if needle/Node ever populates one.
         if (!response.request) {
             const outgoingHeaders = this.titleCaseHeaders(response.req?.getHeaders?.());
             response.request = {
@@ -350,14 +308,10 @@ export class Request {
     }
 
     /**
-     * Title-case an HTTP header name the way `request`/`postman-request` preserved it on the outgoing
-     * request (`Content-Type`, `User-Agent`, `WWW-Authenticate`, ...). needle lowercases outgoing header
-     * names, so we re-case them to maximize parity with what consumers saw on `response.request.headers`.
+     * Title-case an outgoing header name (`Content-Type`, `User-Agent`, ...): needle lowercases them,
+     * but `request` preserved the casing consumers saw on `response.request.headers`.
      */
     private titleCaseHeaderName(name: string): string {
-        //title-case each hyphen-delimited segment (Content-Type, User-Agent, Authorization, ...). This
-        //covers the outgoing request headers roku-deploy sends; we don't special-case acronym headers
-        //(WWW-Authenticate etc.) because those are response headers, not outgoing-request headers.
         return name.split('-').map(part => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()).join('-');
     }
 
@@ -376,9 +330,7 @@ export class Request {
 export const request = new Request();
 
 /**
- * The subset of the legacy `request`/`postman-request` options object that roku-deploy actually
- * builds and this shim consumes. Declared explicitly (rather than depending on `@types/request`
- * purely for a type) so every field reads type-safely.
+ * The subset of the legacy `request` options object that roku-deploy builds and this shim consumes.
  */
 export interface RequestOptions {
 
@@ -416,12 +368,9 @@ export interface RequestOptions {
 }
 
 /**
- * The `response` object roku-deploy (and its consumers) see. Both `postman-request` and `needle`
- * hand back a Node `http.IncomingMessage`, so the real object carries far more than the few fields
- * roku-deploy reads — `statusCode`, `headers`, `statusMessage`, `rawHeaders`, `httpVersion*`,
- * `socket`, `req`, `complete`, etc. We keep all of that (it's needle's actual IncomingMessage) and
- * layer on the `request`-compat extras postman added. The interface therefore declares the fields we
- * guarantee, and allows the rest of the IncomingMessage surface via the index signature.
+ * The `response` object roku-deploy (and its consumers) see: needle's actual `http.IncomingMessage`
+ * plus the `request`-compat extras. Declares the fields we guarantee; the index signature allows
+ * the rest of the IncomingMessage surface.
  */
 export interface RequestResponse {
     statusCode: number;

--- a/src/util.ts
+++ b/src/util.ts
@@ -149,12 +149,9 @@ export class Util {
         const isFileSystemCaseSensitive = await this.getIsFileSystemCaseSensitive(cwd);
 
         const globResults = patterns.map(async (pattern) => {
-            //Canonicalize separators so callers can use either style: convert every backslash
-            //to a forward slash EXCEPT `\[` and `\]`. This is the one rule that disambiguates
-            //the overloaded Windows backslash without guessing: literal-bracket escapes are the
-            //only glob escape with no backslash-free alternative (use `[*]`/`[?]` for a literal
-            //`*`/`?`), and `path.*` joins never emit `\[`/`\]` on their own. So a surviving
-            //backslash can only be an intentional bracket escape; everything else was a separator.
+            //canonicalize separators so callers can use either style: every backslash becomes a forward
+            //slash EXCEPT the literal-bracket escapes `\[` and `\]`, the only glob escapes with no
+            //backslash-free alternative (use `[*]`/`[?]` for a literal `*`/`?`)
             pattern = pattern.replace(/\\(?![[\]])/g, '/');
             //skip negated patterns (we will use them to filter later on)
             if (pattern.startsWith('!')) {
@@ -272,21 +269,10 @@ export class Util {
     }
 
     /**
-     * Given an array of `FilesType`, normalize them each into a `StandardizedFileEntry`.
-     * Each entry in the array or inner `src` array will be extracted out into its own object.
-     * This makes it easier to reason about later on in the process.
-     * @param files
-     */
-    /**
-     * Standardize a glob `src` pattern from the `files` array. fast-glob/micromatch require
-     * forward slashes as separators (a backslash is an escape char to them), so we normalize
-     * to posix slashes rather than the OS separator. Callers may pass either separator style
-     * (e.g. the backslashes that `path.join` produces on Windows); both canonicalize the same.
-     * Preserves:
-     * - the leading `!` glob-negation prefix that `path.normalize` would otherwise consume
-     * - literal-bracket glob escapes (`\[`, `\]`), the one escape with no backslash-free
-     *   alternative, which `path.normalize` would otherwise collapse into path separators.
-     *   (To match a literal `*`/`?` in a filename, use the `[*]`/`[?]` char-class form instead.)
+     * Standardize a glob `src` pattern from the `files` array to posix separators (fast-glob/micromatch
+     * treat a backslash as an escape char), accepting either separator style from callers.
+     * Preserves the leading `!` negation prefix and the literal-bracket escapes `\[`/`\]` that
+     * `path.normalize` would otherwise mangle. (For a literal `*`/`?`, use `[*]`/`[?]` instead.)
      */
     public standardizeSrcPattern(pattern: string) {
         const isNegated = pattern.startsWith('!');

--- a/src/util.ts
+++ b/src/util.ts
@@ -59,7 +59,7 @@ export class Util {
     }
 
     /**
-     * Normalize path and replace all directory separators with current OS separators
+     * Normalize path and replace all directory separators with forward slashes
      * @param thePath
      */
     public standardizePathPosix(thePath: string) {
@@ -128,9 +128,7 @@ export class Util {
             return false;
         }
 
-        //get a list of every file in the parent directory for this file
         const filesInDir = await fsExtra.readdir(parentDirPath);
-        //look at each file path until we find the one we're searching for
         for (let dirFile of filesInDir) {
             const dirFilePath = this.standardizePath(`${parentDirPath}/${dirFile}`);
             if (dirFilePath.toLowerCase() === lowerFilePath) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -149,7 +149,8 @@ export class Util {
         const globResults = patterns.map(async (pattern) => {
             //canonicalize separators so callers can use either style: every backslash becomes a forward
             //slash EXCEPT the literal-bracket escapes `\[` and `\]`, the only glob escapes with no
-            //backslash-free alternative (use `[*]`/`[?]` for a literal `*`/`?`)
+            //backslash-free alternative (use `[*]`/`[?]` for a literal `*`/`?`). `path.*` joins never
+            //emit `\[`/`\]` on their own, so a surviving backslash can only be an intentional bracket escape
             pattern = pattern.replace(/\\(?![[\]])/g, '/');
             //skip negated patterns (we will use them to filter later on)
             if (pattern.startsWith('!')) {


### PR DESCRIPTION
Closes #350

Comment-only pass over `src/`: trimmed verbose docblocks and needle-migration essays down to 1–3 lines (keeping the behavioral gotchas), deleted comments that just restated the adjacent code, and fixed a stale copy-pasted docblock on `standardizePathPosix` (now says forward slashes, not OS separators).