### PR TITLE
Include response headers in EcpResult

### DIFF
--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -976,7 +976,7 @@ describe('RokuDeploy', () => {
 
             const result = await rd.sendEcpRequest({ id: 123 }, 'query/device-info');
 
-            expect(result).to.eql({ status: undefined, body: undefined });
+            expect(result).to.eql({ status: undefined, headers: {}, body: undefined });
         });
 
         it('retries against a refreshed instance url when the mesh reports the cached instance gone', async () => {

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -825,6 +825,20 @@ describe('RokuDeploy', () => {
             expect(stub.getCall(0).args[0].url).to.equal('http://1.1.1.1:8060/query/device-info');
             expect(result.status).to.equal(200);
             expect(result.body).to.equal('<device-info><model-name>Roku</model-name></device-info>');
+            expect(result.headers).to.eql({});
+        });
+
+        it('returns the response headers so callers can pick a parser from the content-type', async () => {
+            sinon.stub(rokuDeploy as any, 'doGetRequest').callsFake(() => {
+                return Promise.resolve({
+                    response: { statusCode: 200, headers: { 'content-type': 'text/xml; charset="utf-8"' } },
+                    body: '<device-info />'
+                });
+            });
+
+            const result = await rokuDeploy.sendEcpRequest({ host: '1.1.1.1' }, 'query/device-info');
+
+            expect(result.headers).to.eql({ 'content-type': 'text/xml; charset="utf-8"' });
         });
 
         it('sends POST requests with a custom ecp port', async () => {
@@ -917,7 +931,7 @@ describe('RokuDeploy', () => {
 
         it('parseEcpXml wraps a parse failure and a non-Error parse rejection', async () => {
             await expectThrowsAsync(async () => {
-                await rokuDeploy['parseEcpXml']({ status: 200, body: '<device-info><unclosed' });
+                await rokuDeploy['parseEcpXml']({ status: 200, body: '<device-info><unclosed', headers: {} });
             }, 'Could not parse ECP response');
 
             //a non-Error rejection from the xml parser must not be attached as the cause
@@ -925,7 +939,7 @@ describe('RokuDeploy', () => {
             sinon.stub(xml2js, 'parseStringPromise').callsFake(() => Promise.reject('not an error instance'));
             let caughtError: errors.UnparsableDeviceResponseError;
             try {
-                await rokuDeploy['parseEcpXml']({ status: 200, body: '<device-info></device-info>' });
+                await rokuDeploy['parseEcpXml']({ status: 200, body: '<device-info></device-info>', headers: {} });
             } catch (e) {
                 caughtError = e as errors.UnparsableDeviceResponseError;
             }

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -2798,7 +2798,10 @@ export interface EcpResult {
     status: number | undefined;
     /** The raw response body (usually XML, empty for command routes like keypress) */
     body: string;
-    /** The response headers (lowercased names), so callers can pick a parser from the content-type. Empty when the transport produced no response */
+    /** 
+     * The response headers (lowercased names), so callers can pick a parser from the content-type. Empty when the transport produced no response 
+     * @see {@link https://nodejs.org/api/http.html#messageheaders | message.headers docs}
+     */
     headers: Record<string, string | string[]>;
 }
 

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -942,7 +942,8 @@ export class RokuDeploy {
 
         return {
             status: response?.response?.statusCode,
-            body: response?.body
+            body: response?.body,
+            headers: response?.response?.headers ?? {}
         };
     }
 
@@ -2788,6 +2789,8 @@ export interface EcpResult {
     status: number | undefined;
     /** The raw response body (usually XML, empty for command routes like keypress) */
     body: string;
+    /** The response headers (lowercased names), so callers can pick a parser from the content-type. Empty when the transport produced no response */
+    headers: Record<string, string | string[]>;
 }
 
 export interface QueryRegistryOptions extends BaseEcpOptions {


### PR DESCRIPTION
Since #351, `sendEcpRequest` returns the raw body and callers parse it themselves - but they had no way to know what they were parsing. `EcpResult` now carries the response headers (lowercased names, an empty object when the transport produced no response) so callers can pick a parser from the content-type.

Motivating consumer: roku-test-automation's ECP migration onto `sendEcpRequest` dispatches on `content-type` to decide between XML and JSON parsing, matching the behavior it previously inherited from needle's auto-parsing.