### PR TITLE
Encode remote keys when building ECP URLs

### DIFF
--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -2242,6 +2242,19 @@ describe('RokuDeploy', () => {
             expect(stub.getCall(0).args[0].url).to.contain('/api/v0/ecp1/keypress/Lit_a');
         });
 
+        it('sends a space character as a URI-encoded literal', async () => {
+            const stub = sinon.stub(rokuDeploy as any, 'doPostRequest').resolves({ response: { statusCode: 200 }, body: '' });
+            await rokuDeploy.sendText({ device: rceDevice, text: ' ' });
+            expect(stub.getCall(0).args[0].url).to.contain('/api/v0/ecp1/keypress/Lit_%20');
+        });
+
+        it('sends one keypress per code point (not per UTF-16 code unit) for an astral character like an emoji', async () => {
+            const stub = sinon.stub(rokuDeploy as any, 'doPostRequest').resolves({ response: { statusCode: 200 }, body: '' });
+            await rokuDeploy.sendText({ device: rceDevice, text: '😀' });
+            expect(stub.callCount).to.equal(1);
+            expect(stub.getCall(0).args[0].url).to.equal(`https://device.rce.roku.com/instance/abc/api/v0/ecp1/keypress/${encodeURIComponent('Lit_😀')}`);
+        });
+
         it('routes keydown and keyup through the instance-api route', async () => {
             const stub = sinon.stub(rokuDeploy as any, 'doPostRequest').resolves({ response: { statusCode: 200 }, body: '' });
             await rokuDeploy.keyDown({ device: rceDevice, key: 'Down' });
@@ -2322,6 +2335,24 @@ describe('RokuDeploy', () => {
 
             expect(result.status).to.equal(200);
             expect(stub.getCall(1).args[0].url).to.equal('https://device.rce.roku.com/instance/abc/ecp1/keypress/Home');
+        });
+
+        it('canonicalizes then URI-encodes a literal key on the instance-api route', async () => {
+            const stub = sinon.stub(rokuDeploy as any, 'doPostRequest').resolves({ response: { statusCode: 200 }, body: '' });
+            await rokuDeploy.keyPress({ device: rceDevice, key: 'lit_&' });
+            expect(stub.getCall(0).args[0].url).to.equal('https://device.rce.roku.com/instance/abc/api/v0/ecp1/keypress/Lit_%26');
+        });
+
+        it('URI-encodes a literal space key on the direct HTTP ECP path', async () => {
+            const stub = sinon.stub(rokuDeploy as any, 'doPostRequest').resolves({ response: { statusCode: 200 }, body: '' });
+            await rokuDeploy.keyPress({ device: { host: '1.2.3.4' }, key: 'Lit_ ' });
+            expect(stub.getCall(0).args[0].url).to.equal('http://1.2.3.4:8060/keypress/Lit_%20');
+        });
+
+        it('URI-encodes a literal ampersand key on the direct HTTP ECP path', async () => {
+            const stub = sinon.stub(rokuDeploy as any, 'doPostRequest').resolves({ response: { statusCode: 200 }, body: '' });
+            await rokuDeploy.keyPress({ device: { host: '1.2.3.4' }, key: 'Lit_&' });
+            expect(stub.getCall(0).args[0].url).to.equal('http://1.2.3.4:8060/keypress/Lit_%26');
         });
     });
 

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -980,11 +980,10 @@ export class RokuDeploy {
     public async sendText(options: SendTextOptions) {
         options = { ...this.options, ...options } as SendTextOptions;
         this.checkRequiredOptions(options, ['device', 'text']);
-        const chars = options.text.split('');
-        for (const char of chars) {
+        for (const char of options.text) {
             await this.sendKeyEvent({
                 ...options,
-                key: `lit_${encodeURIComponent(char)}`,
+                key: `lit_${char}`,
                 action: 'keypress'
             });
         }
@@ -2005,10 +2004,10 @@ export class RokuDeploy {
                 if (!rceToken) {
                     throw new Error('An rceToken is required to reach ECP on an RCE device');
                 }
-                const key = this.toCanonicalRemoteKey(options.key);
+                const canonicalKey = this.toCanonicalRemoteKey(options.key);
                 const response = await this.withRceInstanceUrlRetry(deviceConfig, async () => {
                     const instanceUrl = await this.getRceInstanceUrl(deviceConfig);
-                    const url = `${instanceUrl}/api/v0/ecp1/${options.action}/${key}`;
+                    const url = `${instanceUrl}/api/v0/ecp1/${options.action}/${encodeURIComponent(canonicalKey)}`;
                     return this.doPostRequest({ url: url, timeout: options.timeout ?? RokuDeploy.defaults.ecpTimeout, headers: this.buildRceAuthHeaders(rceToken) }, true);
                 });
                 return {
@@ -2020,7 +2019,7 @@ export class RokuDeploy {
             }
         }
 
-        return this.sendEcpRequest(options.device, `${options.action}/${options.key}`, {
+        return this.sendEcpRequest(options.device, `${options.action}/${encodeURIComponent(options.key)}`, {
             method: 'POST',
             ecpPort: options.ecpPort,
             timeout: options.timeout
@@ -2656,15 +2655,18 @@ export interface SendKeyEventOptions extends BaseEcpOptions {
 }
 
 export interface KeyUpOptions extends BaseEcpOptions {
-    key: RemoteKeyText;
+    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+    key: RemoteKeyText | string;
 }
 
 export interface KeyDownOptions extends BaseEcpOptions {
-    key: RemoteKeyText;
+    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+    key: RemoteKeyText | string;
 }
 
 export interface KeyPressOptions extends BaseEcpOptions {
-    key: RemoteKeyText;
+    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+    key: RemoteKeyText | string;
 }
 
 export interface SendTextOptions extends BaseEcpOptions {
@@ -2798,8 +2800,8 @@ export interface EcpResult {
     status: number | undefined;
     /** The raw response body (usually XML, empty for command routes like keypress) */
     body: string;
-    /** 
-     * The response headers (lowercased names), so callers can pick a parser from the content-type. Empty when the transport produced no response 
+    /**
+     * The response headers (lowercased names), so callers can pick a parser from the content-type. Empty when the transport produced no response
      * @see {@link https://nodejs.org/api/http.html#messageheaders | message.headers docs}
      */
     headers: Record<string, string | string[]>;

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -952,6 +952,11 @@ export class RokuDeploy {
         };
     }
 
+    /**
+     * Press and release a remote-control key. Pass the key raw (e.g. `Lit_&` for a literal
+     * character) - it is URI-encoded when the URL is built, so a pre-encoded value gets
+     * double-encoded.
+     */
     public async keyPress(options: KeyPressOptions) {
         options = { ...this.options, ...options } as KeyPressOptions;
         return this.sendKeyEvent({
@@ -961,6 +966,10 @@ export class RokuDeploy {
         });
     }
 
+    /**
+     * Press a remote-control key without releasing it (pair with `keyUp`). Pass the key raw -
+     * it is URI-encoded when the URL is built, so a pre-encoded value gets double-encoded.
+     */
     public async keyDown(options: KeyDownOptions) {
         options = { ...this.options, ...options } as KeyDownOptions;
         return this.sendKeyEvent({
@@ -969,6 +978,10 @@ export class RokuDeploy {
         });
     }
 
+    /**
+     * Release a remote-control key held by `keyDown`. Pass the key raw - it is URI-encoded when
+     * the URL is built, so a pre-encoded value gets double-encoded.
+     */
     public async keyUp(options: KeyUpOptions) {
         options = { ...this.options, ...options } as KeyUpOptions;
         return this.sendKeyEvent({
@@ -977,6 +990,10 @@ export class RokuDeploy {
         });
     }
 
+    /**
+     * Type text on the device by sending each character as a `Lit_` keypress. Pass the text raw -
+     * each character is URI-encoded when the URL is built, so pre-encoded text gets double-encoded.
+     */
     public async sendText(options: SendTextOptions) {
         options = { ...this.options, ...options } as SendTextOptions;
         this.checkRequiredOptions(options, ['device', 'text']);


### PR DESCRIPTION
`sendKeyEvent` now URI-encodes the key when it builds the ECP URL, on both routes:

- RCE instance-api route: canonicalizes via `toCanonicalRemoteKey`, then encodes the result into the URL
- direct ECP route: encodes the key into the `${action}/` route

`sendEcpRequest` itself is unchanged.

Previously the key went into the URL raw, so a `Lit_` key containing a space, `&`, or `#` produced a corrupt request, and consumers had to pre-encode as a workaround. That workaround now needs to be removed wherever it exists, since encoding twice will double-encode the key. Consumer updates for vscode-brightscript-language and roku-test-automation are prepared and will land alongside.

`sendText` dropped its own per-character `encodeURIComponent` (it would now double-encode through `sendKeyEvent`) and switched from `text.split('')` to `for...of`, fixing a bug where astral characters (emoji) were split into lone surrogates and `encodeURIComponent` threw `URIError: URI malformed`.

`KeyUpOptions`, `KeyDownOptions`, and `KeyPressOptions.key` are widened from `RemoteKeyText` to `RemoteKeyText | string`, matching `SendKeyEventOptions.key`, so literal `Lit_...` keys no longer need a cast.

Closes #374
