### PR TITLE
Tag RCE 502 upgrade rejections as ECONNREFUSED

### DIFF
--- a/src/RokuDeploySocket.spec.ts
+++ b/src/RokuDeploySocket.spec.ts
@@ -416,6 +416,39 @@ describe('createRokuDeploySocket', () => {
 
             expect(emittedError?.message).to.contain('handshake failed');
             expect(emittedEventNames).to.eql(['error', 'close']);
+            expect((emittedError as NodeJS.ErrnoException).code).to.be.undefined;
+        });
+
+        it(`tags a 502 upgrade rejection with code 'ECONNREFUSED', matching the LAN retry signal (nothing on the device is listening yet)`, async () => {
+            const telnetSocket = createRceTelnetSocket();
+            let emittedError: NodeJS.ErrnoException | undefined;
+            telnetSocket.on('error', (error: NodeJS.ErrnoException) => {
+                emittedError = error;
+            });
+
+            telnetSocket.connect();
+            await flushMicrotasks();
+            fakeWebSocket.emit('error', new Error('Unexpected server response: 502'));
+            await flushMicrotasks();
+
+            expect(emittedError?.message).to.contain('Unexpected server response: 502');
+            expect(emittedError?.code).to.equal('ECONNREFUSED');
+        });
+
+        it('leaves a 404 upgrade rejection with no code, so it stays non-retryable (the port is not whitelisted)', async () => {
+            const telnetSocket = createRceTelnetSocket();
+            let emittedError: NodeJS.ErrnoException | undefined;
+            telnetSocket.on('error', (error: NodeJS.ErrnoException) => {
+                emittedError = error;
+            });
+
+            telnetSocket.connect();
+            await flushMicrotasks();
+            fakeWebSocket.emit('error', new Error('Unexpected server response: 404'));
+            await flushMicrotasks();
+
+            expect(emittedError?.message).to.contain('Unexpected server response: 404');
+            expect(emittedError?.code).to.be.undefined;
         });
 
         it('emits error then close when the instance url fails to resolve', async () => {

--- a/src/RokuDeploySocket.ts
+++ b/src/RokuDeploySocket.ts
@@ -217,7 +217,7 @@ export class RceSocket extends stream.Duplex {
             }
         });
         webSocket.on('error', (error: Error) => {
-            this.failConnection(new Error(`RCE telnet websocket error for ${url}: ${error.message}`));
+            this.failConnection(this.wrapWebSocketError(url, error));
         });
         webSocket.once('close', () => {
             //the connection is gone in both directions, so end both sides of the stream and let it
@@ -443,6 +443,20 @@ export class RceSocket extends stream.Duplex {
             return;
         }
         this.destroy(error);
+    }
+
+    /**
+     * A 502 upgrade rejection means the port is open but nothing is listening yet (channel still
+     * booting) — the same transient condition a local device reports as `ECONNREFUSED`, so it gets
+     * that code and consumers retry it. Everything else (e.g. 404 port-not-whitelisted) stays
+     * code-less and fatal. `ws` only exposes the status inside the message, hence the match.
+     */
+    private wrapWebSocketError(url: string, error: Error): NodeJS.ErrnoException {
+        const wrappedError: NodeJS.ErrnoException = new Error(`RCE telnet websocket error for ${url}: ${error.message}`);
+        if (/Unexpected server response: 502\b/.test(error.message)) {
+            wrappedError.code = 'ECONNREFUSED';
+        }
+        return wrappedError;
     }
 
     private buildWebSocketUrl(instanceUrl: string): string {


### PR DESCRIPTION
RceSocket wraps websocket upgrade failures from the RCE port bridge (`/api/v0/ports/{port}`) as plain errors with no `code`, so consumers can't tell a transient failure from a fatal one. When the sideloaded channel hasn't started listening on the port yet, the bridge rejects the upgrade with HTTP 502; a local device hits the same condition and reports it as `ECONNREFUSED`. A 404 (port not whitelisted) is permanently fatal and shouldn't be retried.

`wrapWebSocketError` now tags the 502 case with `code: 'ECONNREFUSED'` so it matches the local-device signal, while 404 and everything else stay code-less. The match is on the error message text ("Unexpected server response: 502") because the `ws` library doesn't expose the HTTP status on the error object.

Consumers that already retry on `ECONNREFUSED` (e.g. roku-test-automation's OnDeviceComponent) now ride out channel boot on cloud devices instead of failing instantly.
