### PR TITLE
Fix pkg download corruption on RCE devices

### DIFF
--- a/src/rce-device.spec.ts
+++ b/src/rce-device.spec.ts
@@ -299,10 +299,12 @@ const REQUEST_TIMEOUT = 30_000;
     });
 
     describe('deployAndSignPackage', () => {
-        //RCE: signing on an emulator instance is unverified (rekeying/signing a cloud device has not
-        //been confirmed safe or even meaningful). Skip until that's confirmed; body kept as-is so the
-        //structure survives for the later merge with device.spec.ts.
-        it.skip('works', async () => {
+        it('works', async function deployAndSignPackage() {
+            //rekey + sign + download, then a second rekey using the downloaded pkg: several cloud
+            //round-trips. Bumped well past the suite default for that.
+            this.timeout(120_000);
+
+            //this test rekeys the device (changes its signing key); leaves it rekeyed to `options.devId` when done
             await rd.deleteDevChannel({ device: options.device, password: options.password });
             await rd.rekeyDevice({
                 device: options.device,
@@ -324,6 +326,91 @@ const REQUEST_TIMEOUT = 30_000;
                 manifestPath: `${rootDir}/manifest`
             });
             expectPathExists(pkgPath);
+            //the download is a real Roku package, not an empty file or a proxy error page
+            const pkgBuffer = fsExtra.readFileSync(pkgPath);
+            expect(pkgBuffer.length).to.be.greaterThan(0);
+            expect(pkgBuffer.subarray(0, 17).toString('latin1')).to.equal('Roku Channel PakV');
+
+            //roundtrip proof: rekey the device using the pkg we just downloaded and signed, then
+            //confirm the device's dev id still matches. This only works if the downloaded pkg is a
+            //genuinely valid signed package, so it proves rekey + sign + download all work end to end.
+            await rd.rekeyDevice({
+                device: options.device,
+                password: options.password,
+                pkg: pkgPath,
+                signingPassword: options.signingPassword,
+                devId: options.devId
+            });
+            assert.strictEqual((await rd.getDevId(options)).devId, options.devId);
+        });
+    });
+
+    describe('rekeyDevice', () => {
+        it('rekeys the device', async function rekeyDevice() {
+            //bumped from the LAN suite's default for a couple cloud round-trips (rekey + getDevId)
+            this.timeout(40_000);
+
+            //mutates the device's signing key
+            await rd.rekeyDevice({
+                device: options.device,
+                password: options.password,
+                pkg: rekeySignedPackage,
+                signingPassword: options.signingPassword,
+                devId: options.devId
+            });
+            assert.strictEqual((await rd.getDevId(options)).devId, options.devId);
+        });
+
+        it('throws when the signing password is wrong', async function rekeyDeviceWrongPassword() {
+            this.timeout(40_000);
+
+            //rekey with the correct password first so the device's key state is known
+            await rd.rekeyDevice({
+                device: options.device,
+                password: options.password,
+                pkg: rekeySignedPackage,
+                signingPassword: options.signingPassword,
+                devId: options.devId
+            });
+
+            let thrown: Error;
+            try {
+                await rd.rekeyDevice({
+                    device: options.device,
+                    password: options.password,
+                    pkg: rekeySignedPackage,
+                    signingPassword: 'NOT_THE_SIGNING_PASSWORD',
+                    devId: options.devId
+                });
+            } catch (e) {
+                thrown = e as Error;
+            }
+            try {
+                assert.ok(thrown, 'expected rekeyDevice to throw for a wrong signing password');
+                assert.ok(
+                    thrown instanceof errors.FailedDeviceResponseError,
+                    `expected FailedDeviceResponseError, got ${thrown?.constructor?.name}: ${thrown?.message}`
+                );
+                //firmware 15.x reports this via the response body's roku messages ("Signature verification
+                //failed."), which checkRequest throws before rekeyDevice's own "Rekey Failure:" parsing runs;
+                //accept either shape so the test survives firmware messaging differences
+                assert.ok(
+                    /Signature verification failed|^Rekey Failure:/.test(thrown.message),
+                    `expected a signature/rekey failure message, got: ${thrown.message}`
+                );
+                //a failed rekey leaves the device with NO key (keyed-developer-id comes back empty)
+                assert.strictEqual((await rd.getDevId(options)).devId, '');
+            } finally {
+                //always restore the key (rekeyDevice self-verifies the resulting dev id) so a failed
+                //assertion can't leave the shared device with no key
+                await rd.rekeyDevice({
+                    device: options.device,
+                    password: options.password,
+                    pkg: rekeySignedPackage,
+                    signingPassword: options.signingPassword,
+                    devId: options.devId
+                });
+            }
         });
     });
 

--- a/src/request.spec.ts
+++ b/src/request.spec.ts
@@ -68,6 +68,12 @@ describe('request (needle shim)', () => {
             expect(postArgs.options.response_timeout).to.equal(12345);
         });
 
+        it('sets decode_response=false (needle charset-decoding corrupts binary downloads served with a charset)', async () => {
+            stubPost(null, { statusCode: 200, headers: {} }, 'ok');
+            await callPost({ url: 'http://1.2.3.4:80/plugin_package', formData: { a: 'b' } });
+            expect(postArgs.options.decode_response).to.equal(false);
+        });
+
         it('does NOT set read_timeout (its lingering re-armed timer leaks a handle in the digest-auth path)', async () => {
             stubPost(null, { statusCode: 200, headers: {} }, 'ok');
             await callPost({ url: 'http://1.2.3.4:80/plugin_install', timeout: 12345, formData: { a: 'b' } });

--- a/src/request.ts
+++ b/src/request.ts
@@ -135,6 +135,11 @@ export class Request {
         const needleOptions: needle.NeedleOptions = {
             //Roku responses are HTML/XML that roku-deploy parses by hand; never let needle auto-parse them
             parse_response: false,
+            //never let needle charset-decode a response: a signed pkg download served with a charset in its
+            //content-type (the RCE instance proxy does this) would have every non-utf8 byte replaced with
+            //U+FFFD, corrupting the binary. `request` never transcoded either (plain utf8 only), so this is
+            //also parity; `coerceBody` handles the Buffer->string conversion for text paths.
+            decode_response: false,
             //`request` had a single `timeout` that governed how long to wait to establish the connection and
             //receive a response. Map it to needle's `open_timeout` (connection) and `response_timeout` (time to
             //first response byte). Deliberately do NOT set `read_timeout`: needle's read-timer is re-armed on


### PR DESCRIPTION
The RCE instance proxy serves the signed pkg download with a charset in its content-type. Needle's default charset-decoding then replaces every non-utf8 byte with U+FFFD, silently corrupting the binary pkg. The ASCII "Roku Channel PakV 2.0" header survives that corruption, so the file looks valid until it's actually used, e.g. rekeying with it fails with "Signature verification failed.: iostream error". LAN devices are unaffected since they serve the pkg without a charset in the content-type.

Fixed in the needle shim (src/request.ts) by setting `decode_response: false`. This also restores parity with the old request library, which never charset-transcoded responses.

Added a unit test in src/request.spec.ts pinning `decode_response: false` in the option-translation suite.

In src/rce-device.spec.ts:
- Un-skipped `deployAndSignPackage > works` (previously skipped as unverified on an emulator) and strengthened it: after createSignedPackage it now asserts the downloaded file starts with the "Roku Channel PakV" magic header, then rekeys the device using that downloaded pkg and verifies the dev id as a roundtrip proof that rekey, sign, and download all work end to end
- Added a `rekeyDevice` describe with a happy-path rekey verified via getDevId, and a wrong-signing-password test that asserts a FailedDeviceResponseError (accepting either the firmware's "Signature verification failed" roku-message or the library's "Rekey Failure:" prefix), confirms the failed rekey leaves the device with an empty keyed-developer-id, and restores the key in a finally

Verified against a live RCE device: all three new/updated tests pass, the full rce-device suite passes (30 passing), and the unit suite passes (879).