### PR TITLE
Add format property to CaptureScreenshotResult

### DIFF
--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -5411,6 +5411,7 @@ describe('RokuDeploy', () => {
             mockDoPostRequest(body);
             let result = await rokuDeploy.captureScreenshot({ device: options.device, password: 'password', out: true });
             expect(result.buffer).to.be.instanceOf(Buffer);
+            expect(result.format).to.equal('png');
             expect(result.filePath).not.to.be.undefined;
             expect(path.extname(result.filePath)).to.equal('.png');
             expect(fsExtra.existsSync(result.filePath));
@@ -5439,6 +5440,7 @@ describe('RokuDeploy', () => {
             mockDoPostRequest(body);
             let result = await rokuDeploy.captureScreenshot({ device: options.device, password: 'password', out: true });
             expect(result.buffer).to.be.instanceOf(Buffer);
+            expect(result.format).to.equal('jpg');
             expect(result.filePath).not.to.be.undefined;
             expect(path.extname(result.filePath)).to.equal('.jpg');
             expect(fsExtra.existsSync(result.filePath));

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -715,7 +715,10 @@ export class RokuDeploy {
         // Always download to buffer
         const buffer = await this.downloadToBuffer(requestParams);
 
-        const result: CaptureScreenshotResult = { buffer: buffer };
+        const result: CaptureScreenshotResult = {
+            buffer: buffer,
+            format: deviceExt.slice(1).toLowerCase() as 'jpg' | 'png'
+        };
 
         // If out is provided, also save to disk
         if (options.out) {
@@ -2586,6 +2589,10 @@ export interface CaptureScreenshotResult {
      * The screenshot image data
      */
     buffer: Buffer;
+    /**
+     * The image format of the buffer, as reported by the device
+     */
+    format: 'jpg' | 'png';
     /**
      * The file path where the screenshot was saved (only present when `out` option was provided)
      */

--- a/src/cli.spec.ts
+++ b/src/cli.spec.ts
@@ -190,7 +190,7 @@ describe('cli', function cli() {
 
     it('Takes a screenshot', async () => {
         const stub = sinon.stub(rokuDeploy, 'captureScreenshot').callsFake(async () => {
-            return Promise.resolve({ buffer: Buffer.from(''), filePath: '' });
+            return Promise.resolve({ buffer: Buffer.from(''), format: 'jpg' as const, filePath: '' });
         });
 
         const command = new CaptureScreenshotCommand();
@@ -210,7 +210,7 @@ describe('cli', function cli() {
 
     it('Takes a screenshot using the provided cwd', async () => {
         const stub = sinon.stub(rokuDeploy, 'captureScreenshot').callsFake(async () => {
-            return Promise.resolve({ buffer: Buffer.from(''), filePath: '' });
+            return Promise.resolve({ buffer: Buffer.from(''), format: 'jpg' as const, filePath: '' });
         });
 
         const command = new CaptureScreenshotCommand();


### PR DESCRIPTION
Adds a `format` property to `CaptureScreenshotResult`

`captureScreenshot()` returns a buffer, but without writing it to disk there was no way to know whether the device produced a jpg or a png. The device reports the extension in its `plugin_inspect` response (the same value already used for file naming), so now it's passed through on the result:

```ts
const { buffer, format } = await rokuDeploy.captureScreenshot({ device, password });
// format: 'jpg' | 'png'
```

Notes:
- Typed as the union 'jpg' | 'png' (no leading dot) rather than the raw extension string — the screenshot-URL regex only ever matches those two, and a union is more useful to consumers than string parsing.
- Reports what the device said it produced (from the URL), not byte-sniffing — same trust the existing autoExtension file-naming logic already places in that value.
- format is required, so consumers stubbing captureScreenshot will get a compile error until they add it — v4 is in alpha, so no back-compat shim.

Closes #381