### PR TITLE
Rename getFilePaths to resolveFilesArray

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Can't find what you need? We offer a variety of functions available in the [Roku
 - `stage()`
 - `zip()`
 - `sideload()`
-- `getFilePaths()`
+- `resolveFilesArray()`
 - `keyPress()`
 - `keyUp()`
 - `keyDown()`

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -4789,8 +4789,8 @@ describe('RokuDeploy', () => {
                     ]
                 };
 
-                //getFilePaths detects the file
-                expect(await rokuDeploy.getFilePaths({ files: ['renamed_test.md'], rootDir: opts.rootDir })).to.eql([{
+                //resolveFilesArray detects the file
+                expect(await rokuDeploy.resolveFilesArray({ files: ['renamed_test.md'], rootDir: opts.rootDir })).to.eql([{
                     src: s`${opts.rootDir}/renamed_test.md`,
                     dest: s`renamed_test.md`
                 }]);
@@ -4832,9 +4832,9 @@ describe('RokuDeploy', () => {
                     ]
                 };
 
-                //getFilePaths detects the file
+                //resolveFilesArray detects the file
                 expect(
-                    (await rokuDeploy.getFilePaths({ files: opts.files, rootDir: opts.rootDir })).sort((a, b) => a.src.localeCompare(b.src))
+                    (await rokuDeploy.resolveFilesArray({ files: opts.files, rootDir: opts.rootDir })).sort((a, b) => a.src.localeCompare(b.src))
                 ).to.eql([{
                     src: s`${tempDir}/mainProject/source/lib/lib.brs`,
                     dest: s`source/lib/lib.brs`
@@ -5909,7 +5909,7 @@ describe('RokuDeploy', () => {
         });
     });
 
-    describe('getFilePaths', () => {
+    describe('resolveFilesArray', () => {
         const otherProjectName = 'otherProject';
         const otherProjectDir = sp`${rootDir}/../${otherProjectName}`;
         //create baseline project structure
@@ -5928,14 +5928,14 @@ describe('RokuDeploy', () => {
             ]);
         });
 
-        async function getFilePaths(files: FileEntry[], rootDirOverride = rootDir) {
-            return (await rokuDeploy.getFilePaths({ files: files, rootDir: rootDirOverride }))
+        async function resolveFilesArray(files: FileEntry[], rootDirOverride = rootDir) {
+            return (await rokuDeploy.resolveFilesArray({ files: files, rootDir: rootDirOverride }))
                 .sort((a, b) => a.src.localeCompare(b.src));
         }
 
         describe('top-level-patterns', () => {
             it('excludes a file that is negated', async () => {
-                expect(await getFilePaths([
+                expect(await resolveFilesArray([
                     'source/**/*',
                     '!source/main.brs'
                 ])).to.eql([{
@@ -5946,7 +5946,7 @@ describe('RokuDeploy', () => {
 
             it('excludes file from non-rootdir top-level pattern', async () => {
                 writeFiles(rootDir, ['../externalDir/source/main.brs']);
-                expect(await getFilePaths([
+                expect(await resolveFilesArray([
                     '../externalDir/**/*',
                     '!../externalDir/**/*'
                 ])).to.eql([]);
@@ -5955,7 +5955,7 @@ describe('RokuDeploy', () => {
             it('throws when using top-level string referencing file outside the root dir', async () => {
                 writeFiles(rootDir, [`../source/main.brs`]);
                 await expectThrowsAsync(async () => {
-                    await getFilePaths([
+                    await resolveFilesArray([
                         '../source/**/*'
                     ]);
                 }, 'Cannot reference a file outside of rootDir when using a top-level string. Please use a src;des; object instead');
@@ -5963,7 +5963,7 @@ describe('RokuDeploy', () => {
 
             it('works for brighterscript files', async () => {
                 writeFiles(rootDir, ['src/source/main.bs']);
-                expect(await getFilePaths([
+                expect(await resolveFilesArray([
                     'manifest',
                     'source/**/*.bs'
                 ], s`${rootDir}/src`)).to.eql([{
@@ -5973,7 +5973,7 @@ describe('RokuDeploy', () => {
             });
 
             it('works for root-level double star in top-level pattern', async () => {
-                expect(await getFilePaths([
+                expect(await resolveFilesArray([
                     '**/*'
                 ])).to.eql([{
                     src: s`${rootDir}/components/component1.brs`,
@@ -6005,7 +6005,7 @@ describe('RokuDeploy', () => {
             });
 
             it('works for multile entries', async () => {
-                expect(await getFilePaths([
+                expect(await resolveFilesArray([
                     'source/**/*',
                     'components/**/*',
                     'manifest'
@@ -6038,7 +6038,7 @@ describe('RokuDeploy', () => {
                     'source/lib.brs',
                     'source/main.brs'
                 ]);
-                expect(await getFilePaths([
+                expect(await resolveFilesArray([
                     'source/*.brs'
                 ])).to.eql([{
                     src: s`${rootDir}/source/lib.brs`,
@@ -6050,7 +6050,7 @@ describe('RokuDeploy', () => {
             });
 
             it('works for double-star globs', async () => {
-                expect(await getFilePaths([
+                expect(await resolveFilesArray([
                     '**/*.brs'
                 ])).to.eql([{
                     src: s`${rootDir}/components/component1.brs`,
@@ -6068,7 +6068,7 @@ describe('RokuDeploy', () => {
             });
 
             it('copies subdir-level relative double-star globs', async () => {
-                expect(await getFilePaths([
+                expect(await resolveFilesArray([
                     'components/**/*.brs'
                 ])).to.eql([{
                     src: s`${rootDir}/components/component1.brs`,
@@ -6081,7 +6081,7 @@ describe('RokuDeploy', () => {
 
             it('Finds folder using square brackets glob pattern', async () => {
                 fsExtra.outputFileSync(`${rootDir}/e/file.brs`, '');
-                expect(await getFilePaths(
+                expect(await resolveFilesArray(
                     [
                         '[test]/*'
                     ],
@@ -6095,7 +6095,7 @@ describe('RokuDeploy', () => {
             it('Finds folder with escaped square brackets glob pattern as name', async () => {
                 fsExtra.outputFileSync(`${rootDir}/[test]/file.brs`, '');
                 fsExtra.outputFileSync(`${rootDir}/e/file.brs`, '');
-                expect(await getFilePaths(
+                expect(await resolveFilesArray(
                     [
                         '\\[test\\]/*'
                     ],
@@ -6111,14 +6111,14 @@ describe('RokuDeploy', () => {
                     'manifest'
                 ]);
                 await expectThrowsAsync(
-                    getFilePaths([
+                    resolveFilesArray([
                         `../${otherProjectName}/**/*`
                     ])
                 );
             });
 
             it('applies negated patterns', async () => {
-                expect(await getFilePaths([
+                expect(await resolveFilesArray([
                     //include all components
                     'components/**/*.brs',
                     //exclude all xml files
@@ -6138,7 +6138,7 @@ describe('RokuDeploy', () => {
             });
 
             it('handles negated multi-globs', async () => {
-                expect((await getFilePaths([
+                expect((await resolveFilesArray([
                     'components/**/*',
                     '!components/screen1/**/*'
                 ])).map(x => x.dest)).to.eql([
@@ -6149,7 +6149,7 @@ describe('RokuDeploy', () => {
 
             it('allows negating paths outside rootDir without requiring src;dest; syntax', async () => {
                 fsExtra.outputFileSync(`${rootDir}/../externalLib/source/lib.brs`, '');
-                const filePaths = await getFilePaths([
+                const filePaths = await resolveFilesArray([
                     'source/**/*',
                     { src: '../externalLib/**/*', dest: 'source' },
                     '!../externalLib/source/**/*'
@@ -6163,7 +6163,7 @@ describe('RokuDeploy', () => {
             });
 
             it('applies multi-glob paths relative to rootDir', async () => {
-                expect(await getFilePaths([
+                expect(await resolveFilesArray([
                     'manifest',
                     'source/**/*',
                     'components/**/*',
@@ -6193,7 +6193,7 @@ describe('RokuDeploy', () => {
             });
 
             it('ignores non-glob folder paths', async () => {
-                expect(await getFilePaths([
+                expect(await resolveFilesArray([
                     //this is the folder called "components"
                     'components'
                 ])).to.eql([]); //there should be no matches because rokudeploy ignores folders
@@ -6203,7 +6203,7 @@ describe('RokuDeploy', () => {
 
         describe('{src;dest} objects', () => {
             it('excludes a file that is negated in src;dest;', async () => {
-                expect(await getFilePaths([
+                expect(await resolveFilesArray([
                     'source/**/*',
                     {
                         src: '!source/main.brs'
@@ -6215,7 +6215,7 @@ describe('RokuDeploy', () => {
             });
 
             it('works for root-level double star in {src;dest} object', async () => {
-                expect(await getFilePaths([{
+                expect(await resolveFilesArray([{
                     src: '**/*',
                     dest: ''
                 }
@@ -6254,7 +6254,7 @@ describe('RokuDeploy', () => {
                     'manifest',
                     'source/thirdPartyLib.brs'
                 ]);
-                expect(await getFilePaths([{
+                expect(await resolveFilesArray([{
                     src: `${otherProjectDir}/**/*`
                 }])).to.eql([{
                     src: s`${otherProjectDir}/components/component1/subComponent/screen.brs`,
@@ -6272,7 +6272,7 @@ describe('RokuDeploy', () => {
                 writeFiles(otherProjectDir, [
                     'source/thirdPartyLib.brs'
                 ]);
-                expect(await getFilePaths([{
+                expect(await resolveFilesArray([{
                     src: `${otherProjectDir}/source/thirdPartyLib.brs`,
                     dest: 'lib/thirdPartyLib.brs'
                 }])).to.eql([{
@@ -6286,7 +6286,7 @@ describe('RokuDeploy', () => {
                 writeFiles(rootDir, [
                     'source/main.brs'
                 ]);
-                expect(await getFilePaths([{
+                expect(await resolveFilesArray([{
                     src: `../${rootDirName}/source/main.brs`,
                     dest: 'source/main.brs'
                 }])).to.eql([{
@@ -6301,7 +6301,7 @@ describe('RokuDeploy', () => {
                     'manifest',
                     'source/thirdPartyLib.brs'
                 ]);
-                expect(await getFilePaths([{
+                expect(await resolveFilesArray([{
                     src: `../otherProject/**/*`,
                     dest: 'outFolder/'
                 }])).to.eql([{
@@ -6317,7 +6317,7 @@ describe('RokuDeploy', () => {
             });
 
             it('works for other globs', async () => {
-                expect(await getFilePaths([{
+                expect(await resolveFilesArray([{
                     src: `components/screen1/*creen1.brs`,
                     dest: s`/source`
                 }])).to.eql([{
@@ -6333,7 +6333,7 @@ describe('RokuDeploy', () => {
                     'components/screen1/screen1.brs',
                     'components/screen1/screen1.xml'
                 ]);
-                expect(await getFilePaths([
+                expect(await resolveFilesArray([
                     //include all component brs files
                     'components/**/*.brs',
                     //exclude all xml files
@@ -6359,7 +6359,7 @@ describe('RokuDeploy', () => {
                 'images/splash_hd.jpg'
             ]);
             //sanity check, make sure it works without fiddling with cwd intact
-            let paths = await getFilePaths([
+            let paths = await resolveFilesArray([
                 'manifest',
                 'images/splash_hd.jpg'
             ]);
@@ -6377,7 +6377,7 @@ describe('RokuDeploy', () => {
             let wrongCwd = path.dirname(path.resolve(options.rootDir));
             process.chdir(wrongCwd);
 
-            paths = await getFilePaths([
+            paths = await resolveFilesArray([
                 'manifest',
                 'images/splash_hd.jpg'
             ]);
@@ -6393,7 +6393,7 @@ describe('RokuDeploy', () => {
 
         it('supports absolute paths from outside of the rootDir', async () => {
             //dest not specified
-            expect(await getFilePaths([{
+            expect(await resolveFilesArray([{
                 src: sp`${cwd}/README.md`
             }], options.rootDir)).to.eql([{
                 src: s`${cwd}/README.md`,
@@ -6401,7 +6401,7 @@ describe('RokuDeploy', () => {
             }]);
 
             //dest specified
-            expect(await getFilePaths([{
+            expect(await resolveFilesArray([{
                 src: sp`${cwd}/README.md`,
                 dest: 'docs/README.md'
             }], options.rootDir)).to.eql([{
@@ -6411,7 +6411,7 @@ describe('RokuDeploy', () => {
 
             let paths: any[];
 
-            paths = await getFilePaths([{
+            paths = await resolveFilesArray([{
                 src: sp`${cwd}/README.md`,
                 dest: s`docs/README.md`
             }], outDir);
@@ -6423,7 +6423,7 @@ describe('RokuDeploy', () => {
 
             //top-level string paths pointing to files outside the root should thrown an exception
             await expectThrowsAsync(async () => {
-                paths = await getFilePaths([
+                paths = await resolveFilesArray([
                     sp`${cwd}/README.md`
                 ], outDir);
             });
@@ -6434,7 +6434,7 @@ describe('RokuDeploy', () => {
                 'README.md'
             ]);
             expect(
-                await getFilePaths([{
+                await resolveFilesArray([{
                     src: sp`../README.md`
                 }], rootDir)
             ).to.eql([{
@@ -6443,7 +6443,7 @@ describe('RokuDeploy', () => {
             }]);
 
             expect(
-                await getFilePaths([{
+                await resolveFilesArray([{
                     src: sp`../README.md`,
                     dest: 'docs/README.md'
                 }], rootDir)
@@ -6458,14 +6458,14 @@ describe('RokuDeploy', () => {
                 '../README.md'
             ]);
             await expectThrowsAsync(
-                getFilePaths([
+                resolveFilesArray([
                     path.posix.join('..', 'README.md')
                 ], outDir)
             );
         });
 
         it('supports overriding paths', async () => {
-            let paths = await getFilePaths([{
+            let paths = await resolveFilesArray([{
                 src: sp`${rootDir}/components/component1.brs`,
                 dest: 'comp1.brs'
             }, {
@@ -6497,7 +6497,7 @@ describe('RokuDeploy', () => {
                         dest: 'components/MainScene.brs'
                     }
                 ];
-                let paths = await getFilePaths(files, thisRootDir);
+                let paths = await resolveFilesArray(files, thisRootDir);
 
                 //the MainScene.brs file from source should NOT be included
                 let mainSceneEntries = paths.filter(x => s`${x.dest}` === s`components/MainScene.brs`);
@@ -6515,7 +6515,7 @@ describe('RokuDeploy', () => {
         it('maintains original file path', async () => {
             fsExtra.outputFileSync(`${rootDir}/components/CustomButton.brs`, '');
             expect(
-                await getFilePaths([
+                await resolveFilesArray([
                     'components/CustomButton.brs'
                 ], rootDir)
             ).to.eql([{
@@ -6527,7 +6527,7 @@ describe('RokuDeploy', () => {
         it('correctly assumes file path if not given', async () => {
             fsExtra.outputFileSync(`${rootDir}/components/CustomButton.brs`, '');
             expect(
-                (await getFilePaths([
+                (await resolveFilesArray([
                     { src: 'components/*' }
                 ], rootDir)).sort((a, b) => a.src.localeCompare(b.src))
             ).to.eql([{

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -116,7 +116,7 @@ export class RokuDeploy {
             throw new Error(`rootDir does not exist at "${rootDir}"`);
         }
 
-        let fileObjects = await this.getFilePaths({ files: files, rootDir: rootDir });
+        let fileObjects = await this.resolveFilesArray({ files: files, rootDir: rootDir });
         await Promise.all(fileObjects.map(async (fileObject) => {
             let destFilePath = util.standardizePath(`${out}/${fileObject.dest}`);
 
@@ -165,7 +165,7 @@ export class RokuDeploy {
         const files = options.files ?? ['**/*'];
 
         // Check that manifest will be included
-        const filePaths = await this.getFilePaths({ files: files, rootDir: dir });
+        const filePaths = await this.resolveFilesArray({ files: files, rootDir: dir });
         const hasManifest = filePaths.some(f => f.dest.toLowerCase() === 'manifest');
         if (!hasManifest) {
             throw new Error(`Cannot zip package: missing manifest file in "${dir}"`);
@@ -1416,10 +1416,12 @@ export class RokuDeploy {
     }
 
     /**
-    * Get all file paths for the specified options
-    */
-    public async getFilePaths(options: GetFilePathsOptions): Promise<StandardizedFileEntry[]> {
-        options = { ...this.options, ...options } as GetFilePathsOptions;
+     * Resolve the `files` array into the concrete list of `{src, dest}` file mappings used to
+     * build the staging folder: globs expanded against `rootDir`, each match paired with its
+     * destination path inside the package.
+     */
+    public async resolveFilesArray(options: ResolveFilesArrayOptions): Promise<StandardizedFileEntry[]> {
+        options = { ...this.options, ...options } as ResolveFilesArrayOptions;
         let rootDir = options.rootDir;
         const files = options.files;
 
@@ -1505,7 +1507,7 @@ export class RokuDeploy {
      * @param files a files array used to filter the files from `srcFolder`
      */
     private async makeZip(srcFolder: string, zipFilePath: string, files: FileEntry[] = ['**/*']) {
-        const filePaths = await this.getFilePaths({ files: files, rootDir: srcFolder });
+        const filePaths = await this.resolveFilesArray({ files: files, rootDir: srcFolder });
 
         const zip = new JSZip();
         // Allows us to wait until all are done before we build the zip
@@ -2651,7 +2653,7 @@ export interface ExitAppOptions extends BaseEcpOptions {
     force?: boolean;
 }
 
-export interface GetFilePathsOptions {
+export interface ResolveFilesArrayOptions {
     files: FileEntry[];
     rootDir: string;
 }


### PR DESCRIPTION
Implements the decision on #366: `getFilePaths` is a core capability with a name that didn't say what it does — resolve the `files` array into the `{src, dest}` mappings used to build the staging folder. Renamed to `resolveFilesArray`, and `GetFilePathsOptions` → `ResolveFilesArrayOptions` to match.

Mechanical rename (method, internal callers, specs, readme) plus a docblock that now actually describes the behavior. No functional changes.

Closes #366