### PR TITLE
Support top-level patterns to external dirs using globstar

### DIFF
--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -4527,7 +4527,7 @@ describe('RokuDeploy', () => {
             expectPathExists(`${stagingDir}/source/main.brs`);
         });
 
-        it('should support external folders with globstar (#77)', async () => {
+        it('should support external folders with globstar', async () => {
             //write a file outside of rootDir
             fsExtra.outputFileSync(`${tempDir}/thirdPartySDK/alpha/beta/charlie.brs`, '');
             writeFiles(rootDir, [
@@ -5973,7 +5973,7 @@ describe('RokuDeploy', () => {
                 ])).to.eql([]);
             });
 
-            it('supports top-level strings to external dirs when they contain a globstar (#77)', async () => {
+            it('supports top-level strings to external dirs when they contain a globstar', async () => {
                 writeFiles(rootDir, [`../thirdPartySDK/source/sdk.brs`]);
                 expect(await resolveFilesArray([
                     '../thirdPartySDK/**/*'
@@ -6157,7 +6157,7 @@ describe('RokuDeploy', () => {
                 }]);
             });
 
-            it('resolves top-level strings referencing files not under rootDir via their globstar (#77)', async () => {
+            it('resolves top-level strings referencing files not under rootDir via their globstar', async () => {
                 writeFiles(otherProjectDir, [
                     'manifest'
                 ]);

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -4527,6 +4527,27 @@ describe('RokuDeploy', () => {
             expectPathExists(`${stagingDir}/source/main.brs`);
         });
 
+        it('should support external folders with globstar (#77)', async () => {
+            //write a file outside of rootDir
+            fsExtra.outputFileSync(`${tempDir}/thirdPartySDK/alpha/beta/charlie.brs`, '');
+            writeFiles(rootDir, [
+                'manifest',
+                'source/main.brs'
+            ]);
+            await rokuDeploy.stage({
+                rootDir: rootDir,
+                out: stagingDir,
+                files: [
+                    '../thirdPartySDK/**/*',
+                    '**/*'
+                ]
+            });
+            expectPathExists(`${stagingDir}/manifest`);
+            expectPathExists(`${stagingDir}/source/main.brs`);
+            //the external file lands at its globstar-relative path
+            expectPathExists(`${stagingDir}/alpha/beta/charlie.brs`);
+        });
+
         it('handles copying a simple directory by name using src;dest;', async () => {
             writeFiles(rootDir, [
                 'manifest',
@@ -5952,13 +5973,43 @@ describe('RokuDeploy', () => {
                 ])).to.eql([]);
             });
 
-            it('throws when using top-level string referencing file outside the root dir', async () => {
+            it('supports top-level strings to external dirs when they contain a globstar (#77)', async () => {
+                writeFiles(rootDir, [`../thirdPartySDK/source/sdk.brs`]);
+                expect(await resolveFilesArray([
+                    '../thirdPartySDK/**/*'
+                ])).to.eql([{
+                    src: s`${rootDir}/../thirdPartySDK/source/sdk.brs`,
+                    dest: s`source/sdk.brs`
+                }]);
+            });
+
+            it('uses the FIRST globstar as the start of the dest-relative path', async () => {
+                writeFiles(rootDir, [`../sdk/alpha/beta/charlie.brs`]);
+                expect(await resolveFilesArray([
+                    '../sdk/**/beta/**/*'
+                ])).to.eql([{
+                    src: s`${rootDir}/../sdk/alpha/beta/charlie.brs`,
+                    //dest starts at the first globstar: everything under ../sdk/
+                    dest: s`alpha/beta/charlie.brs`
+                }]);
+            });
+
+            it('still throws for an external top-level string without a globstar', async () => {
                 writeFiles(rootDir, [`../source/main.brs`]);
                 await expectThrowsAsync(async () => {
                     await resolveFilesArray([
-                        '../source/**/*'
+                        '../source/main.brs'
                     ]);
-                }, 'Cannot reference a file outside of rootDir when using a top-level string. Please use a src;des; object instead');
+                }, 'Cannot reference a file outside of rootDir when using a top-level string without a globstar (**). Please use a globstar or a src;dest; object instead');
+            });
+
+            it('still throws for an external top-level single-star glob (no globstar)', async () => {
+                writeFiles(rootDir, [`../source/main.brs`]);
+                await expectThrowsAsync(async () => {
+                    await resolveFilesArray([
+                        '../source/*.brs'
+                    ]);
+                }, 'Cannot reference a file outside of rootDir when using a top-level string without a globstar (**). Please use a globstar or a src;dest; object instead');
             });
 
             it('works for brighterscript files', async () => {
@@ -6106,15 +6157,16 @@ describe('RokuDeploy', () => {
                 }]);
             });
 
-            it('throws exception when top-level strings reference files not under rootDir', async () => {
+            it('resolves top-level strings referencing files not under rootDir via their globstar (#77)', async () => {
                 writeFiles(otherProjectDir, [
                     'manifest'
                 ]);
-                await expectThrowsAsync(
-                    resolveFilesArray([
-                        `../${otherProjectName}/**/*`
-                    ])
-                );
+                expect(await resolveFilesArray([
+                    `../${otherProjectName}/**/*`
+                ])).to.eql([{
+                    src: s`${otherProjectDir}/manifest`,
+                    dest: s`manifest`
+                }]);
             });
 
             it('applies negated patterns', async () => {

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -629,12 +629,24 @@ describe('util', () => {
             expect(s`${destPath}`).to.equal(s`source/main.bs`);
         });
 
-        it('excludes a file found outside the root dir', () => {
+        it('resolves a file found outside the root dir via its globstar (#77)', () => {
             expect(
                 util.getDestPath(
                     s`${rootDir}/../source/main.brs`,
                     [
                         '../source/**/*'
+                    ],
+                    rootDir
+                )
+            ).to.eql(s`main.brs`);
+        });
+
+        it('excludes a file outside the root dir when the pattern has no globstar', () => {
+            expect(
+                util.getDestPath(
+                    s`${rootDir}/../source/main.brs`,
+                    [
+                        '../source/*.brs'
                     ],
                     rootDir
                 )

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -629,7 +629,7 @@ describe('util', () => {
             expect(s`${destPath}`).to.equal(s`source/main.bs`);
         });
 
-        it('resolves a file found outside the root dir via its globstar (#77)', () => {
+        it('resolves a file found outside the root dir via its globstar', () => {
             expect(
                 util.getDestPath(
                     s`${rootDir}/../source/main.brs`,

--- a/src/util.ts
+++ b/src/util.ts
@@ -433,9 +433,13 @@ export class Util {
             if (util.isParentOfPath(rootDir, srcPath, false)) {
                 //files that are actually relative to rootDir
                 result = util.stringReplaceInsensitive(srcPath, rootDir, '');
+            } else if ((globstarIdx = entry.indexOf('**')) > -1) {
+                //file outside rootDir reached through a globstar: the FIRST globstar marks where
+                //the dest-relative portion of the path begins (same rule as src;dest; entries)
+                const rootGlobstarPath = path.resolve(rootDir, entry.substring(0, globstarIdx)) + path.sep;
+                result = util.stringReplaceInsensitive(srcPath, rootGlobstarPath, '');
             } else {
-                // result = util.stringReplaceInsensitive(srcPath, rootDir, '');
-                throw new Error('Cannot reference a file outside of rootDir when using a top-level string. Please use a src;des; object instead');
+                throw new Error('Cannot reference a file outside of rootDir when using a top-level string without a globstar (**). Please use a globstar or a src;dest; object instead');
             }
 
             //non-glob-pattern explicit file reference


### PR DESCRIPTION
A top-level string pattern may now reference files outside rootDir as long as it contains a globstar: the FIRST globstar marks where the dest-relative portion of the path begins (the same rule src;dest; entries already used). External top-level strings without a globstar still throw, with the message updated to mention the globstar escape hatch. getDestPath inherits the same behavior.

Closes #77