### PR TITLE
chore: Security enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2702,9 +2702,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+            "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
             "dev": true,
             "funding": [
                 {
@@ -4950,7 +4950,7 @@
                 "globals": "^13.9.0",
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.2.1",
-                "js-yaml": "^4.3.1",
+                "js-yaml": "^4.3.2",
                 "minimatch": "^3.0.4",
                 "strip-json-comments": "^3.1.1"
             },
@@ -4989,7 +4989,7 @@
                 "camelcase": "^5.3.1",
                 "find-up": "^4.1.0",
                 "get-package-type": "^0.1.0",
-                "js-yaml": "^4.3.1",
+                "js-yaml": "^4.3.2",
                 "resolve-from": "^5.0.0"
             },
             "dependencies": {
@@ -5936,7 +5936,7 @@
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
-                "js-yaml": "^4.3.1",
+                "js-yaml": "^4.3.2",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
                 "lodash.merge": "^4.6.2",
@@ -6677,9 +6677,9 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+            "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
             "dev": true,
             "requires": {
                 "argparse": "^2.0.1"
@@ -6937,7 +6937,7 @@
                 "find-up": "^5.0.0",
                 "glob": "^8.1.0",
                 "he": "^1.2.0",
-                "js-yaml": "^4.3.1",
+                "js-yaml": "^4.3.2",
                 "log-symbols": "^4.1.0",
                 "minimatch": "^5.1.6",
                 "ms": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "overrides": {
         "serialize-javascript": "^7.0.5",
         "brace-expansion": "^2.1.4",
-        "js-yaml": "^4.3.1",
+        "js-yaml": "^4.3.2",
         "@babel/core": "^7.29.7"
     },
     "typings": "dist/index.d.ts",


### PR DESCRIPTION
Clears GHSA-2883-xcg3-v3hh (js-yaml, high), the only advisory failing the audit gate.

`npm audit --omit=dev`: **0 vulnerabilities**.

## Ships to consumers
Nothing. The only change is dev-scoped.

## Lockfile only (dev deps)
| Override | Before | After | Reached via |
|---|---|---|---|
| `js-yaml` | `^4.3.1` | `^4.3.2` | `eslint`, `mocha`, `nyc` |

## Notes for the reviewer
- The previous `^4.3.1` pin landed exactly inside the new advisory's range (`4.0.0 - 4.3.1`), so the gate went red without anything in this repo changing. 4.3.2 is a patch bump.

## Verification
`npm run preversion` (build + lint + test) passes, and `npm run audit` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)