### PR TITLE
chore: Fix device tests by increasing timeouts and detecting device reboots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4049,9 +4049,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+            "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
             "dev": true,
             "funding": [
                 {
@@ -7565,7 +7565,7 @@
                 "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
-                "js-yaml": "^4.3.1",
+                "js-yaml": "^4.3.2",
                 "minimatch": "^3.1.2",
                 "strip-json-comments": "^3.1.1"
             }
@@ -7608,7 +7608,7 @@
                 "camelcase": "^5.3.1",
                 "find-up": "^4.1.0",
                 "get-package-type": "^0.1.0",
-                "js-yaml": "^4.3.1",
+                "js-yaml": "^4.3.2",
                 "resolve-from": "^5.0.0"
             },
             "dependencies": {
@@ -8893,7 +8893,7 @@
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
                 "is-path-inside": "^3.0.3",
-                "js-yaml": "^4.3.1",
+                "js-yaml": "^4.3.2",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
                 "lodash.merge": "^4.6.2",
@@ -10077,9 +10077,9 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+            "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
             "dev": true,
             "requires": {
                 "argparse": "^2.0.1"
@@ -10352,7 +10352,7 @@
                 "find-up": "^5.0.0",
                 "glob": "^8.1.0",
                 "he": "^1.2.0",
-                "js-yaml": "^4.3.1",
+                "js-yaml": "^4.3.2",
                 "log-symbols": "^4.1.0",
                 "minimatch": "^5.1.6",
                 "ms": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
             "uuid": "^11.1.1"
         },
         "brace-expansion": "^2.1.4",
-        "js-yaml": "^4.3.1",
+        "js-yaml": "^4.3.2",
         "@babel/core": "^7.29.7",
         "browserslist": "^4.28.8"
     },

--- a/src/device.spec.ts
+++ b/src/device.spec.ts
@@ -220,6 +220,8 @@ describe('device', function device() {
             zip: `${outDir}/${name}.zip`,
             appType: 'dcl'
         });
+        //installing a complib can reboot the device; don't return until it's back
+        await waitForDeviceOnline(options.device.host, 120_000, 3000, 0);
     }
 
     /**
@@ -299,8 +301,9 @@ describe('device', function device() {
 
     describe('large zip uploads', function largeZipUploads() {
         //a large upload takes several seconds per digest-auth leg on wifi, and publish() may attempt
-        //Replace + Install; keep this generous
-        this.timeout(120_000);
+        //Replace + Install; keep this generous. The complib test in here can also reboot the device,
+        //which costs up to ~120s to recover from.
+        this.timeout(240_000);
 
         //Large enough that the multipart body cannot fit in the OS socket buffers, so the upload is
         //still mid-write when the device responds to the request. Random bytes are incompressible, so
@@ -566,9 +569,10 @@ describe('device', function device() {
     });
 
     describe('deleteAllSideloadedPlugins', function deleteAllTests() {
-        //these tests do several device round-trips (install + verify + delete). ~2x the slowest
-        //observed case in this block (the multi-library delete, ~10s).
-        this.timeout(20_000);
+        //these tests do several device round-trips (install + verify + delete). Complib installs/deletes
+        //can reboot the device, and each recovery costs up to ~120s, so budget for one on top of the
+        //~20s happy path instead of sizing off the observed runtime alone.
+        this.timeout(150_000);
 
         it('deletes a single channel', async () => {
             //start clean
@@ -601,6 +605,8 @@ describe('device', function device() {
             });
 
             await rd.deleteAllSideloadedPlugins(options);
+            //deleting a complib can reboot the device; wait it out before asserting
+            await waitForDeviceOnline(options.device.host, 120_000, 3000, 0);
 
             //nothing should be installed anymore
             expect(await rd.listSideloadedPlugins({ device: options.device, password: options.password })).to.eql([]);
@@ -620,6 +626,8 @@ describe('device', function device() {
             });
 
             await rd.deleteAllSideloadedPlugins(options);
+            //deleting a complib can reboot the device; wait it out before asserting
+            await waitForDeviceOnline(options.device.host, 120_000, 3000, 0);
 
             //nothing should be installed anymore
             expect(await rd.listSideloadedPlugins({ device: options.device, password: options.password })).to.eql([]);
@@ -640,6 +648,8 @@ describe('device', function device() {
             });
 
             await rd.deleteAllSideloadedPlugins(options);
+            //deleting a complib can reboot the device; wait it out before asserting
+            await waitForDeviceOnline(options.device.host, 120_000, 3000, 0);
 
             //nothing should be installed anymore
             expect(await rd.listSideloadedPlugins({ device: options.device, password: options.password })).to.eql([]);
@@ -673,8 +683,9 @@ describe('device', function device() {
         //Roku firmware rejects sideloaded zips below a hard minimum size (512 bytes on firmware 15.x, for
         //both channels and complibs) with "Unzip failed. Invalid or corrupt zip archive." Each test builds
         //a zip of exactly (BOUNDARY - 1) and exactly BOUNDARY bytes and asserts the former fails, the latter installs.
-        //~2x the slowest observed case in this block (~5.6s).
-        this.timeout(12_000);
+        //Healthy runs take ~5.6s, but these sideload complibs and clear plugins between cases, so leave
+        //room for a device reboot (~120s to recover) rather than sizing off the observed runtime alone.
+        this.timeout(140_000);
         const BOUNDARY = RokuDeploy.MINIMUM_INSTALLABLE_ZIP_SIZE;
 
         //`n` incompressible chars, so 1 char of comment padding == ~1 zip byte and we can converge on an
@@ -1026,9 +1037,10 @@ describe('device', function device() {
     });
 
     describe('deleteComponentLibrary', function deleteComponentLibraryTests() {
-        //these tests install several complibs and then delete them one at a time. ~2x the slowest
-        //observed case in this block (~13s).
-        this.timeout(30_000);
+        //these tests install several complibs and then delete them one at a time. Deleting a complib is
+        //the most reboot-prone thing in this suite and each recovery costs up to ~120s; with up to three
+        //deletes per test, leave room for a couple of recoveries on top of the ~30s happy path.
+        this.timeout(300_000);
 
         it('deletes several component libraries one by one', async () => {
             //start clean
@@ -1052,6 +1064,8 @@ describe('device', function device() {
                     fileName: target
                 });
                 expectedRemaining--;
+                //deleting a complib can reboot the device; wait it out before asserting
+                await waitForDeviceOnline(options.device.host, 120_000, 3000, 0);
 
                 const afterDelete = await getInstalledComponentLibraryFileNames();
                 //the deleted complib should no longer be present...
@@ -1081,6 +1095,8 @@ describe('device', function device() {
                 password: options.password,
                 fileName: toDelete
             });
+            //deleting a complib can reboot the device; wait it out before asserting
+            await waitForDeviceOnline(options.device.host, 120_000, 3000, 0);
 
             //only the second complib should remain
             expect(await getInstalledComponentLibraryFileNames()).to.eql([toKeep]);
@@ -1111,6 +1127,8 @@ describe('device', function device() {
                     password: options.password,
                     fileName: fileName
                 });
+                //deleting a complib can reboot the device; wait it out before the next one
+                await waitForDeviceOnline(options.device.host, 120_000, 3000, 0);
             }
 
             //all complibs gone, but the channel should still be installed


### PR DESCRIPTION
Complib installs and deletes can reboot the device, and recovering from that costs up to ~120s. Several device-test blocks had timeouts sized at ~2x their observed *healthy* runtime (as low as 12s) — shorter than a single recovery cycle, so a mid-test reboot could never do anything but fail. This is what took down the `deleteAllSideloadedPlugins` run in #399.

What changed:
- Timeouts on the four reboot-prone blocks now budget a recovery on top of the happy path: `deleteAllSideloadedPlugins` 20s→150s, `deleteComponentLibrary` 30s→300s, `large zip uploads` 120s→240s, `install size boundary` 12s→140s.
- Added `waitForDeviceOnline` after each complib install/delete so assertions run against a settled device instead of racing one on its way down.

The waits pass `graceMs: 0`, so a healthy device clears on the first poll and the happy path is essentially unchanged.

Verified with typecheck and lint only — the real check is an on-device CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)