### PR TITLE
sendEcpRequest: take a single options object

### DIFF
--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -802,7 +802,7 @@ describe('RokuDeploy', () => {
         it('builds the LAN url from the host and ecp port, defaulting to GET, and returns the raw body', async () => {
             const stub = mockDoGetRequest('<device-info><model-name>Roku</model-name></device-info>');
 
-            const result = await rokuDeploy.sendEcpRequest({ host: '1.1.1.1' }, 'query/device-info');
+            const result = await rokuDeploy.sendEcpRequest({ device: { host: '1.1.1.1' }, route: 'query/device-info' });
 
             expect(stub.getCall(0).args[0].url).to.equal('http://1.1.1.1:8060/query/device-info');
             expect(result.status).to.equal(200);
@@ -818,7 +818,7 @@ describe('RokuDeploy', () => {
                 });
             });
 
-            const result = await rokuDeploy.sendEcpRequest({ host: '1.1.1.1' }, 'query/device-info');
+            const result = await rokuDeploy.sendEcpRequest({ device: { host: '1.1.1.1' }, route: 'query/device-info' });
 
             expect(result.headers).to.eql({ 'content-type': 'text/xml; charset="utf-8"' });
         });
@@ -826,7 +826,7 @@ describe('RokuDeploy', () => {
         it('sends POST requests with a custom ecp port', async () => {
             const stub = mockDoPostRequest();
 
-            await rokuDeploy.sendEcpRequest({ host: '1.1.1.1' }, 'keypress/Home', { method: 'POST', ecpPort: 9060 });
+            await rokuDeploy.sendEcpRequest({ device: { host: '1.1.1.1' }, route: 'keypress/Home', method: 'POST', ecpPort: 9060 });
 
             expect(stub.getCall(0).args[0].url).to.equal('http://1.1.1.1:9060/keypress/Home');
         });
@@ -835,7 +835,7 @@ describe('RokuDeploy', () => {
             const stub = mockDoPostRequest();
             const body = Buffer.from('raw-body-bytes');
 
-            await rokuDeploy.sendEcpRequest({ host: '1.1.1.1' }, 'some/route', { method: 'POST', body: body });
+            await rokuDeploy.sendEcpRequest({ device: { host: '1.1.1.1' }, route: 'some/route', method: 'POST', body: body });
 
             expect(stub.getCall(0).args[0].body).to.equal(body);
         });
@@ -843,7 +843,9 @@ describe('RokuDeploy', () => {
         it('merges caller headers onto the request', async () => {
             const stub = mockDoPostRequest();
 
-            await rokuDeploy.sendEcpRequest({ host: '1.1.1.1' }, 'some/route', {
+            await rokuDeploy.sendEcpRequest({
+                device: { host: '1.1.1.1' },
+                route: 'some/route',
                 method: 'POST',
                 body: 'raw',
                 headers: { 'Content-Type': 'application/octet-stream' }
@@ -855,10 +857,10 @@ describe('RokuDeploy', () => {
         it('routes an RCE device through the instance ECP port proxy with the X-Authorization bearer header', async () => {
             const stub = mockDoGetRequest('<sgrendezvous><status>OK</status></sgrendezvous>');
 
-            const result = await rokuDeploy.sendEcpRequest(
-                { instanceUrl: 'https://device.rce.roku.com/instance/abc', rceToken: 'secret' },
-                'query/sgrendezvous'
-            );
+            const result = await rokuDeploy.sendEcpRequest({
+                device: { instanceUrl: 'https://device.rce.roku.com/instance/abc', rceToken: 'secret' },
+                route: 'query/sgrendezvous'
+            });
 
             expect(stub.getCall(0).args[0].url).to.equal('https://device.rce.roku.com/instance/abc/api/v0/ports/8060/http/query/sgrendezvous');
             expect(stub.getCall(0).args[0].headers).to.eql({ 'X-Authorization': 'Bearer secret' });
@@ -869,7 +871,7 @@ describe('RokuDeploy', () => {
             const rd = new RokuDeploy({ rceToken: 'default-token' });
             const stub = sinon.stub(rd as any, 'doGetRequest').resolves({ statusCode: 200, headers: {}, body: '' });
 
-            await rd.sendEcpRequest({ instanceUrl: 'https://device.rce.roku.com/instance/abc' }, 'query/device-info');
+            await rd.sendEcpRequest({ device: { instanceUrl: 'https://device.rce.roku.com/instance/abc' }, route: 'query/device-info' });
 
             expect(stub.getCall(0).args[0].url).to.equal('https://device.rce.roku.com/instance/abc/api/v0/ports/8060/http/query/device-info');
             expect(stub.getCall(0).args[0].headers).to.eql({ 'X-Authorization': 'Bearer default-token' });
@@ -879,7 +881,7 @@ describe('RokuDeploy', () => {
             const rd = new RokuDeploy({ rceToken: 'default-token' });
             const stub = sinon.stub(rd as any, 'doGetRequest').resolves({ statusCode: 200, headers: {}, body: '' });
 
-            await rd.sendEcpRequest({ instanceUrl: 'https://device.rce.roku.com/instance/abc', rceToken: 'device-token' }, 'query/device-info');
+            await rd.sendEcpRequest({ device: { instanceUrl: 'https://device.rce.roku.com/instance/abc', rceToken: 'device-token' }, route: 'query/device-info' });
 
             expect(stub.getCall(0).args[0].headers).to.eql({ 'X-Authorization': 'Bearer device-token' });
         });
@@ -890,7 +892,7 @@ describe('RokuDeploy', () => {
                 body: '<plugin-registry><status>FAILED</status><error>Device not keyed</error></plugin-registry>'
             });
 
-            const result = await rokuDeploy.sendEcpRequest({ host: '1.1.1.1' }, 'query/registry/dev');
+            const result = await rokuDeploy.sendEcpRequest({ device: { host: '1.1.1.1' }, route: 'query/registry/dev' });
 
             //verification must be off by default so the raw ECP status body comes back
             expect(stub.getCall(0).args[1]).to.equal(false);
@@ -904,7 +906,7 @@ describe('RokuDeploy', () => {
                 body: ''
             });
 
-            await rokuDeploy.sendEcpRequest({ host: '1.1.1.1' }, 'query/device-info', { verify: true });
+            await rokuDeploy.sendEcpRequest({ device: { host: '1.1.1.1' }, route: 'query/device-info', verify: true });
 
             expect(stub.getCall(0).args[1]).to.equal(true);
         });
@@ -915,7 +917,7 @@ describe('RokuDeploy', () => {
                 body: 'no healthy upstream'
             });
 
-            const result = await rokuDeploy.sendEcpRequest({ host: '1.1.1.1' }, 'query/does-not-exist');
+            const result = await rokuDeploy.sendEcpRequest({ device: { host: '1.1.1.1' }, route: 'query/does-not-exist' });
 
             expect(result.status).to.equal(404);
             expect(result.body).to.equal('no healthy upstream');
@@ -927,7 +929,7 @@ describe('RokuDeploy', () => {
                 body: '<device-info><unclosed'
             });
 
-            const result = await rokuDeploy.sendEcpRequest({ host: '1.1.1.1' }, 'query/device-info');
+            const result = await rokuDeploy.sendEcpRequest({ device: { host: '1.1.1.1' }, route: 'query/device-info' });
 
             expect(result.body).to.equal('<device-info><unclosed');
         });
@@ -956,7 +958,7 @@ describe('RokuDeploy', () => {
             });
             sinon.stub(rd as any, 'doGetRequest').resolves(undefined);
 
-            const result = await rd.sendEcpRequest({ id: 123 }, 'query/device-info');
+            const result = await rd.sendEcpRequest({ device: { id: 123 }, route: 'query/device-info' });
 
             expect(result).to.eql({ status: undefined, headers: {}, body: undefined });
         });
@@ -978,7 +980,7 @@ describe('RokuDeploy', () => {
                 return Promise.resolve({ statusCode: 200, headers: {}, body: '<device-info><model-name>Roku</model-name></device-info>' });
             });
 
-            const result = await rd.sendEcpRequest({ id: 123 }, 'query/device-info');
+            const result = await rd.sendEcpRequest({ device: { id: 123 }, route: 'query/device-info' });
 
             expect(stub.callCount).to.equal(2);
             expect(stub.getCall(1).args[0].url).to.equal('https://device.rce.roku.com/instance/new/api/v0/ports/8060/http/query/device-info');
@@ -998,7 +1000,7 @@ describe('RokuDeploy', () => {
                 body: ''
             });
 
-            const result = await rd.sendEcpRequest({ id: 123 }, 'query/does-not-exist');
+            const result = await rd.sendEcpRequest({ device: { id: 123 }, route: 'query/does-not-exist' });
 
             expect(result.status).to.equal(404);
             expect(stub.callCount).to.equal(1);
@@ -1018,7 +1020,7 @@ describe('RokuDeploy', () => {
             });
 
             //verify is off by default, so the caller must get the raw 404 back rather than a throw
-            const result = await rd.sendEcpRequest({ id: 123 }, 'query/device-info');
+            const result = await rd.sendEcpRequest({ device: { id: 123 }, route: 'query/device-info' });
 
             expect(result.status).to.equal(404);
             expect(stub.callCount).to.equal(1);

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -588,7 +588,9 @@ export class RokuDeploy {
 
         let result: EcpResult;
         try {
-            result = await this.sendEcpRequest(options.device, 'query/device-info', {
+            result = await this.sendEcpRequest({
+                device: options.device,
+                route: 'query/device-info',
                 verify: true,
                 ecpPort: options.ecpPort,
                 timeout: options.timeout
@@ -887,18 +889,15 @@ export class RokuDeploy {
      * wrapper exists for it yet. Local devices are addressed as `http://<host>:<ecpPort>/<route>`;
      * Cloud Emulator devices go through their instance's `/api/v0/ports/<ecpPort>/http/<route>` proxy, so callers
      * never branch on device kind.
-     * @param device the device to send the request to
-     * @param route the ECP route without a leading slash (for example `query/device-info`, `keypress/Home`)
-     * @param options `method` defaults to 'GET' (queries); commands like keypress and launch are POSTs.
-     *                `verify` defaults to false so raw ECP status bodies (a 202 `FAILED` registry or
-     *                chanperf response, for example) come back to the caller instead of throwing.
+     * @param options
      */
-    public async sendEcpRequest(device: DeviceOption, route: string, options?: EcpOptions): Promise<EcpResult> {
-        options = { ...this.options, ...options } as EcpOptions;
+    public async sendEcpRequest(options: SendEcpRequestOptions): Promise<EcpResult> {
+        options = { ...this.options, ...options } as SendEcpRequestOptions;
+        this.checkRequiredOptions(options, ['device', 'route']);
         this.validatePort(options.ecpPort, 'ecpPort');
         this.validateTimeout(options.timeout);
 
-        const deviceConfig = this.resolveDevice(device);
+        const deviceConfig = this.resolveDevice(options.device);
         const timeout = options.timeout ?? RokuDeploy.defaults.ecpTimeout;
         const ecpPort = options.ecpPort ?? RokuDeploy.defaults.ecpPort;
 
@@ -911,7 +910,7 @@ export class RokuDeploy {
             instanceGoneResponse = undefined;
             const { baseUrl, headers } = await this.getEcpRequestBase(deviceConfig, ecpPort);
             const requestOptions: RequestOptions = {
-                url: `${baseUrl}/${route}`,
+                url: `${baseUrl}/${options.route}`,
                 timeout: timeout,
                 headers: { ...headers, ...options.headers },
                 body: options.body
@@ -1055,7 +1054,9 @@ export class RokuDeploy {
         this.checkRequiredOptions(options, ['device', 'appId']);
 
         const queryString = this.buildLaunchQueryString(options);
-        await this.sendEcpRequest(options.device, `launch/${encodeURIComponent(options.appId)}${queryString}`, {
+        await this.sendEcpRequest({
+            device: options.device,
+            route: `launch/${encodeURIComponent(options.appId)}${queryString}`,
             method: 'POST',
             verify: true,
             ecpPort: options.ecpPort,
@@ -1072,7 +1073,9 @@ export class RokuDeploy {
         this.checkRequiredOptions(options, ['device', 'appId']);
 
         const forceSegment = options.force ? '/true' : '';
-        const result = await this.sendEcpRequest(options.device, `exit-app/${encodeURIComponent(options.appId)}${forceSegment}`, {
+        const result = await this.sendEcpRequest({
+            device: options.device,
+            route: `exit-app/${encodeURIComponent(options.appId)}${forceSegment}`,
             method: 'POST',
             ecpPort: options.ecpPort,
             timeout: options.timeout
@@ -1111,7 +1114,9 @@ export class RokuDeploy {
         let result: EcpResult;
         let json: Record<string, any> | undefined;
         try {
-            result = await this.sendEcpRequest(options.device, 'query/apps', {
+            result = await this.sendEcpRequest({
+                device: options.device,
+                route: 'query/apps',
                 ecpPort: options.ecpPort,
                 timeout: options.timeout
             });
@@ -1153,7 +1158,9 @@ export class RokuDeploy {
         let result: EcpResult;
         let json: Record<string, any> | undefined;
         try {
-            result = await this.sendEcpRequest(options.device, 'query/active-app', {
+            result = await this.sendEcpRequest({
+                device: options.device,
+                route: 'query/active-app',
                 ecpPort: options.ecpPort,
                 timeout: options.timeout
             });
@@ -1183,7 +1190,9 @@ export class RokuDeploy {
         options = { ...this.options, ...options } as GetRegistryOptions;
         this.checkRequiredOptions(options, ['device', 'appId']);
 
-        const result = await this.sendEcpRequest(options.device, `query/registry/${encodeURIComponent(options.appId)}`, {
+        const result = await this.sendEcpRequest({
+            device: options.device,
+            route: `query/registry/${encodeURIComponent(options.appId)}`,
             ecpPort: options.ecpPort,
             timeout: options.timeout
         });
@@ -1221,7 +1230,9 @@ export class RokuDeploy {
         options = { ...this.options, ...options } as GetAppStateOptions;
         this.checkRequiredOptions(options, ['device', 'appId']);
 
-        const result = await this.sendEcpRequest(options.device, `query/app-state/${encodeURIComponent(options.appId)}`, {
+        const result = await this.sendEcpRequest({
+            device: options.device,
+            route: `query/app-state/${encodeURIComponent(options.appId)}`,
             ecpPort: options.ecpPort,
             timeout: options.timeout
         });
@@ -1248,7 +1259,9 @@ export class RokuDeploy {
         options = { ...this.options, ...options } as GetRendezvousTrackingOptions;
         this.checkRequiredOptions(options, ['device']);
 
-        const result = await this.sendEcpRequest(options.device, 'query/sgrendezvous', {
+        const result = await this.sendEcpRequest({
+            device: options.device,
+            route: 'query/sgrendezvous',
             ecpPort: options.ecpPort,
             timeout: options.timeout
         });
@@ -1276,7 +1289,9 @@ export class RokuDeploy {
         options = { ...this.options, ...options } as SetRendezvousTrackingOptions;
         this.checkRequiredOptions(options, ['device', 'enabled']);
 
-        const result = await this.sendEcpRequest(options.device, `sgrendezvous/${options.enabled ? 'track' : 'untrack'}`, {
+        const result = await this.sendEcpRequest({
+            device: options.device,
+            route: `sgrendezvous/${options.enabled ? 'track' : 'untrack'}`,
             method: 'POST',
             ecpPort: options.ecpPort,
             timeout: options.timeout
@@ -1997,7 +2012,9 @@ export class RokuDeploy {
             }
         }
 
-        return this.sendEcpRequest(options.device, `${options.action}/${encodeURIComponent(options.key)}`, {
+        return this.sendEcpRequest({
+            device: options.device,
+            route: `${options.action}/${encodeURIComponent(options.key)}`,
             method: 'POST',
             ecpPort: options.ecpPort,
             timeout: options.timeout
@@ -2721,7 +2738,9 @@ export interface BaseEcpOptions {
     timeout?: number;
 }
 
-export interface EcpOptions {
+export interface SendEcpRequestOptions extends BaseEcpOptions {
+    /** The ECP route without a leading slash (for example `query/device-info`, `keypress/Home`) */
+    route: string;
     /** The http method for the route; queries are GETs (the default), commands like keypress and launch are POSTs */
     method?: 'GET' | 'POST';
     /** Raw POST body (string or Buffer), sent verbatim with no multipart framing. Ignored for GET requests. */
@@ -2734,10 +2753,6 @@ export interface EcpOptions {
      * come back to the caller instead of throwing.
      */
     verify?: boolean;
-    /** The ECP port for local devices (defaults to 8060); not used for Cloud Emulator devices */
-    ecpPort?: number;
-    /** Request timeout in milliseconds. Defaults to 10000ms (10 seconds) */
-    timeout?: number;
 }
 
 export interface EcpResult {


### PR DESCRIPTION
Fixes #409

`sendEcpRequest(device, route, options)` was the only public method with positional parameters. It now takes a single options object like every other method:

```ts
await rokuDeploy.sendEcpRequest({ device, route: 'query/device-info', timeout: 5000 });
```
- New SendEcpRequestOptions extends BaseEcpOptions (so device, ecpPort, and timeout come from the same base as every other ECP method); route is required via the standard checkRequiredOptions path
- EcpOptions is deleted — its remaining fields (method, body, headers, verify) folded into the new interface
- No behavior changes; 10 internal call sites and specs updated mechanically